### PR TITLE
fix(playbook-views): fix VariableDoesNotExist crash on playbook edit for tagless playbooks

### DIFF
--- a/docs/features/act-2-playbooks/playbooks-edit.feature
+++ b/docs/features/act-2-playbooks/playbooks-edit.feature
@@ -220,3 +220,10 @@ Feature: FOB-PLAYBOOKS-EDIT_PLAYBOOK-1 Edit Playbook
     And she waits 30 seconds without clicking Save
     Then she sees "Draft auto-saved" notification
     And her changes are preserved if she closes and reopens
+
+  Scenario: FOB-PLAYBOOKS-EDIT_PLAYBOOK-25 Edit form renders for playbook with no tags
+    Given Maria owns a playbook with no tags assigned
+    When she opens the edit form
+    Then the Tags field is empty
+    And the form renders without errors
+    And she can add new tags and save successfully

--- a/methodology/playbook_views.py
+++ b/methodology/playbook_views.py
@@ -221,6 +221,7 @@ def playbook_edit(request, pk):
                 'playbook': playbook,
                 'errors': {'name': 'Name is required'},
                 'form_data': request.POST,
+                'tags_string': request.POST.get('tags', ''),
             })
 
         try:
@@ -236,12 +237,14 @@ def playbook_edit(request, pk):
                 'playbook': playbook,
                 'errors': {'name': str(e.message)},
                 'form_data': request.POST,
+                'tags_string': request.POST.get('tags', ''),
             })
 
     return render(request, 'playbooks/edit.html', {
         'playbook': playbook,
         'errors': {},
         'form_data': {},
+        'tags_string': ', '.join(playbook.tags) if playbook.tags else '',
     })
 
 

--- a/methodology/playbook_views.py
+++ b/methodology/playbook_views.py
@@ -215,19 +215,21 @@ def playbook_edit(request, pk):
         description = request.POST.get('description', '').strip()
         category = request.POST.get('category', '').strip()
         visibility = request.POST.get('visibility', '').strip()
+        tags_raw = request.POST.get('tags', '').strip()
+        tags = [t.strip() for t in tags_raw.split(',') if t.strip()]
 
         if not name:
             return render(request, 'playbooks/edit.html', {
                 'playbook': playbook,
                 'errors': {'name': 'Name is required'},
                 'form_data': request.POST,
-                'tags_string': request.POST.get('tags', ''),
+                'tags_string': tags_raw,
             })
 
         try:
             PlaybookService.update_playbook(
                 pk, name=name, description=description,
-                category=category, visibility=visibility
+                category=category, visibility=visibility, tags=tags
             )
             messages.success(request, f"Playbook '{name}' updated successfully!")
             logger.info(f"Playbook {pk} updated by {request.user.username}")

--- a/tests/e2e/test_journey_playbook_edit_no_tags.py
+++ b/tests/e2e/test_journey_playbook_edit_no_tags.py
@@ -1,0 +1,58 @@
+"""User Journey Certification Test for FOB-PLAYBOOKS-EDIT_PLAYBOOK-25.
+
+Scenario: Edit form renders for playbook with no tags.
+"""
+import pytest
+from django.contrib.auth import get_user_model
+from playwright.sync_api import expect
+
+from methodology.models import Playbook
+
+User = get_user_model()
+
+
+@pytest.fixture
+def no_tags_playbook(db):
+    """A playbook with no tags owned by a test user."""
+    user = User.objects.create_user(
+        username='journey_edit_user',
+        password='testpass123',
+    )
+    playbook = Playbook.objects.create(
+        name='Tagless Playbook',
+        description='A playbook with no tags assigned',
+        category='development',
+        author=user,
+        tags=[],
+    )
+    return {'user': user, 'playbook': playbook}
+
+
+@pytest.mark.e2e
+def test_edit_form_renders_for_playbook_with_no_tags(page, live_server, no_tags_playbook):
+    """EDIT_PLAYBOOK-25: Edit form opens without errors for a tagless playbook."""
+    user = no_tags_playbook['user']
+    playbook = no_tags_playbook['playbook']
+
+    # Login
+    page.goto(f'{live_server.url}/auth/user/login/')
+    page.get_by_test_id('login-username-input').fill(user.username)
+    page.get_by_test_id('login-password-input').fill('testpass123')
+    page.get_by_test_id('login-submit-button').click()
+    expect(page).to_have_url(f'{live_server.url}/dashboard/')
+
+    # Navigate to edit form
+    page.goto(f'{live_server.url}/playbooks/{playbook.pk}/edit/')
+    expect(page).to_have_url(f'{live_server.url}/playbooks/{playbook.pk}/edit/')
+
+    # Form renders without error — tags field is empty
+    tags_input = page.get_by_test_id('playbook-tags-input')
+    expect(tags_input).to_be_visible()
+    expect(tags_input).to_have_value('')
+
+    # Can add tags and save successfully
+    tags_input.fill('ux, research')
+    page.get_by_test_id('save-button').click()
+
+    # Redirected to detail page after save
+    expect(page).to_have_url(f'{live_server.url}/playbooks/{playbook.pk}/')

--- a/tests/e2e/test_journey_playbook_edit_no_tags.py
+++ b/tests/e2e/test_journey_playbook_edit_no_tags.py
@@ -12,7 +12,7 @@ User = get_user_model()
 
 
 @pytest.fixture
-def no_tags_playbook(db):
+def no_tags_playbook(transactional_db):
     """A playbook with no tags owned by a test user."""
     user = User.objects.create_user(
         username='journey_edit_user',
@@ -50,9 +50,14 @@ def test_edit_form_renders_for_playbook_with_no_tags(page, live_server, no_tags_
     expect(tags_input).to_be_visible()
     expect(tags_input).to_have_value('')
 
-    # Can add tags and save successfully
+    # Add tags and save
     tags_input.fill('ux, research')
     page.get_by_test_id('save-button').click()
 
     # Redirected to detail page after save
     expect(page).to_have_url(f'{live_server.url}/playbooks/{playbook.pk}/')
+
+    # Reopen edit form — tags are persisted and pre-filled
+    page.goto(f'{live_server.url}/playbooks/{playbook.pk}/edit/')
+    expect(page).to_have_url(f'{live_server.url}/playbooks/{playbook.pk}/edit/')
+    expect(page.get_by_test_id('playbook-tags-input')).to_have_value('ux, research')

--- a/tests/integration/test_playbook_edit.py
+++ b/tests/integration/test_playbook_edit.py
@@ -1,8 +1,8 @@
 """
 Integration tests for Playbook EDIT operation.
 
-Covers the edit form GET/POST lifecycle, specifically ensuring
-tags_string is always present in the template context.
+Covers the edit form GET/POST lifecycle, including tags_string context
+presence, tags persistence on save, and the ValidationError render path.
 """
 
 import pytest
@@ -81,6 +81,32 @@ class TestPlaybookEdit:
         assert response.status_code == 200
         assert response.context['tags_string'] == ''
 
+    # --- POST: ValidationError path (duplicate name) ---
+
+    def test_edit_post_duplicate_name_tags_string_in_context(self):
+        """tags_string is preserved in context when POST fails due to duplicate name."""
+        self._make_playbook()
+        pb2 = Playbook.objects.create(
+            name='Other Playbook',
+            description='Another one',
+            category='development',
+            author=self.user,
+            tags=[],
+        )
+        response = self.client.post(
+            reverse('playbook_edit', kwargs={'pk': pb2.pk}),
+            {
+                'name': 'Test Playbook',
+                'description': 'Updated',
+                'category': 'development',
+                'visibility': 'private',
+                'tags': 'ux, research',
+            },
+        )
+        assert response.status_code == 200
+        assert 'tags_string' in response.context
+        assert response.context['tags_string'] == 'ux, research'
+
     # --- POST: success ---
 
     def test_edit_post_success_redirects(self):
@@ -99,3 +125,35 @@ class TestPlaybookEdit:
         assert response['Location'] == reverse('playbook_detail', kwargs={'pk': pb.pk})
         pb.refresh_from_db()
         assert pb.name == 'Updated Name'
+
+    def test_edit_post_tags_are_persisted(self):
+        """Tags submitted in POST are saved to the playbook."""
+        pb = self._make_playbook(tags=[])
+        self.client.post(
+            reverse('playbook_edit', kwargs={'pk': pb.pk}),
+            {
+                'name': 'Test Playbook',
+                'description': 'Desc',
+                'category': 'development',
+                'visibility': 'private',
+                'tags': 'ux, research',
+            },
+        )
+        pb.refresh_from_db()
+        assert pb.tags == ['ux', 'research']
+
+    def test_edit_post_tags_cleared_when_empty(self):
+        """Submitting empty tags clears the playbook tags."""
+        pb = self._make_playbook(tags=['ux', 'research'])
+        self.client.post(
+            reverse('playbook_edit', kwargs={'pk': pb.pk}),
+            {
+                'name': 'Test Playbook',
+                'description': 'Desc',
+                'category': 'development',
+                'visibility': 'private',
+                'tags': '',
+            },
+        )
+        pb.refresh_from_db()
+        assert pb.tags == []

--- a/tests/integration/test_playbook_edit.py
+++ b/tests/integration/test_playbook_edit.py
@@ -1,0 +1,101 @@
+"""
+Integration tests for Playbook EDIT operation.
+
+Covers the edit form GET/POST lifecycle, specifically ensuring
+tags_string is always present in the template context.
+"""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from methodology.models import Playbook
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestPlaybookEdit:
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username='edit_user', password='testpass123'
+        )
+        self.client.force_login(self.user)
+
+    def _make_playbook(self, tags=None):
+        return Playbook.objects.create(
+            name='Test Playbook',
+            description='Desc',
+            category='development',
+            author=self.user,
+            tags=tags or [],
+        )
+
+    # --- GET ---
+
+    def test_edit_get_renders_200(self):
+        """GET /playbooks/<pk>/edit/ returns 200."""
+        pb = self._make_playbook()
+        response = self.client.get(reverse('playbook_edit', kwargs={'pk': pb.pk}))
+        assert response.status_code == 200
+
+    def test_edit_get_tags_string_in_context_no_tags(self):
+        """tags_string is empty string when playbook has no tags."""
+        pb = self._make_playbook(tags=[])
+        response = self.client.get(reverse('playbook_edit', kwargs={'pk': pb.pk}))
+        assert response.status_code == 200
+        assert 'tags_string' in response.context
+        assert response.context['tags_string'] == ''
+
+    def test_edit_get_tags_string_in_context_with_tags(self):
+        """tags_string is comma-joined when playbook has tags."""
+        pb = self._make_playbook(tags=['product', 'discovery'])
+        response = self.client.get(reverse('playbook_edit', kwargs={'pk': pb.pk}))
+        assert response.status_code == 200
+        assert response.context['tags_string'] == 'product, discovery'
+
+    # --- POST: empty name (validation error path) ---
+
+    def test_edit_post_empty_name_tags_string_in_context(self):
+        """tags_string is preserved in context when POST fails due to empty name."""
+        pb = self._make_playbook()
+        response = self.client.post(
+            reverse('playbook_edit', kwargs={'pk': pb.pk}),
+            {'name': '', 'tags': 'ux, research'},
+        )
+        assert response.status_code == 200
+        assert 'tags_string' in response.context
+        assert response.context['tags_string'] == 'ux, research'
+
+    def test_edit_post_empty_name_tags_string_empty_when_not_submitted(self):
+        """tags_string is empty string when tags not included in failing POST."""
+        pb = self._make_playbook()
+        response = self.client.post(
+            reverse('playbook_edit', kwargs={'pk': pb.pk}),
+            {'name': ''},
+        )
+        assert response.status_code == 200
+        assert response.context['tags_string'] == ''
+
+    # --- POST: success ---
+
+    def test_edit_post_success_redirects(self):
+        """Valid POST updates playbook and redirects to detail."""
+        pb = self._make_playbook()
+        response = self.client.post(
+            reverse('playbook_edit', kwargs={'pk': pb.pk}),
+            {
+                'name': 'Updated Name',
+                'description': 'Updated',
+                'category': 'development',
+                'visibility': 'private',
+            },
+        )
+        assert response.status_code == 302
+        assert response['Location'] == reverse('playbook_detail', kwargs={'pk': pb.pk})
+        pb.refresh_from_db()
+        assert pb.name == 'Updated Name'


### PR DESCRIPTION
## Summary
- The edit page (`/playbooks/<pk>/edit/`) crashed with `VariableDoesNotExist` during template rendering for any playbook with no tags, blocking access to the edit view entirely for those playbooks
- Root cause: template used `{{ form_data.tags|default:tags_string }}` but the view never passed `tags_string` in context — Django's `default` filter doesn't suppress a missing variable on its right-hand side
- Fixed all three render paths in `playbook_edit` (GET, POST empty-name, POST ValidationError) to always include `tags_string`
- Fixed a second silent bug: tags submitted via the edit form were never read from POST data or passed to `update_playbook`, so edits were silently dropped — now parsed and persisted correctly
- Added scenario `FOB-PLAYBOOKS-EDIT_PLAYBOOK-25` to the product spec to explicitly cover the no-tags edge case

## Test plan
- [ ] `pytest tests/integration/test_playbook_edit.py -v` — 9 integration tests, all green
- [ ] `pytest tests/e2e/test_journey_playbook_edit_no_tags.py -v` — Playwright journey test, green
- [ ] Open `/playbooks/<pk>/edit/` for a playbook with no tags — no crash, tags field empty
- [ ] Open `/playbooks/<pk>/edit/` for a playbook with tags — tags pre-filled
- [ ] Submit edit form with empty name — page re-renders without crash, tags field preserved
- [ ] Edit tags and save — reopen edit form and verify tags are persisted

## Changes

### `methodology/playbook_views.py` (updated)
- Added `tags_string` to all three render paths (GET, POST empty-name, POST ValidationError)
- Added tag parsing: reads `tags` from POST data, splits on commas, passes `tags=[...]` to `PlaybookService.update_playbook`

### `tests/integration/test_playbook_edit.py` (updated — 6 existing + 3 added)
Existing tests (unchanged):
- `test_edit_get_renders_200`
- `test_edit_get_tags_string_in_context_no_tags`
- `test_edit_get_tags_string_in_context_with_tags`
- `test_edit_post_empty_name_tags_string_in_context`
- `test_edit_post_empty_name_tags_string_empty_when_not_submitted`
- `test_edit_post_success_redirects`

Added to address review comments:
- `test_edit_post_duplicate_name_tags_string_in_context` — ValidationError render path preserves `tags_string`
- `test_edit_post_tags_are_persisted` — tags submitted in POST are saved to the model
- `test_edit_post_tags_cleared_when_empty` — submitting empty tags clears the model tags

### `tests/e2e/test_journey_playbook_edit_no_tags.py` (updated)
- Fixed fixture: `db` → `transactional_db` so live_server thread sees committed records
- Strengthened assertion: after saving, reopens the edit form and verifies tags are pre-filled with saved values

### `docs/features/act-2-playbooks/playbooks-edit.feature` (updated)
- Added scenario 25: edit form renders without errors for a playbook with no tags, tags field is empty, new tags can be added and saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)