### PR TITLE
fix(mcp): restore and harden create_activity and update_activity — phase_id, ValidationError handling, full test coverage

### DIFF
--- a/docs/features/act-13-mcp/interact-with-activities-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-activities-via-mcp.feature
@@ -31,6 +31,8 @@ Feature: FOB-MCP-ACTIVITIES-1 AI Assistant Interacts with Activities via MCP
       | workflow_id |                      1 |
     And grandparent playbook version is incremented from "0.2" to "0.3"
     And activity is assigned auto-incremented order number
+    # NOTE: "phase" parameter is accepted by the tool without error but is not currently
+    # persisted to the database. Use update_activity with phase_id to assign a Phase model.
 
   Scenario: FOB-MCP-CONFIG-ACTIVITIES-CREATE_ACTIVITY-1 Create with predecessor
     Given workflow (id=1) has activity "Define Props" (id=1)

--- a/docs/features/act-13-mcp/interact-with-activities-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-activities-via-mcp.feature
@@ -19,20 +19,20 @@ Feature: FOB-MCP-ACTIVITIES-1 AI Assistant Interacts with Activities via MCP
 
   Scenario: FOB-MCP-CONFIG-ACTIVITIES-CREATE_ACTIVITY
     Given draft playbook (id=1, version=0.2) has workflow (id=1)
+    And playbook has phase (id=3, name="Planning")
     When Cascade calls MCP tool "create_activity" with:
       | workflow_id |                                       1 |
       | name        | Define Props Interface                  |
       | guidance    | Document component props and prop types |
-      | phase       | Planning                                |
+      | phase_id    |                                       3 |
     Then MCP returns success with activity:
       | id          |                      1 |
       | name        | Define Props Interface |
       | order       |                      1 |
       | workflow_id |                      1 |
+      | phase_id    |                      3 |
     And grandparent playbook version is incremented from "0.2" to "0.3"
     And activity is assigned auto-incremented order number
-    # NOTE: "phase" parameter is accepted by the tool without error but is not currently
-    # persisted to the database. Use update_activity with phase_id to assign a Phase model.
 
   Scenario: FOB-MCP-CONFIG-ACTIVITIES-CREATE_ACTIVITY-1 Create with predecessor
     Given workflow (id=1) has activity "Define Props" (id=1)

--- a/mcp_integration/tools.py
+++ b/mcp_integration/tools.py
@@ -539,7 +539,6 @@ async def create_activity(workflow_id: int, name: str, guidance: str = "",
         workflow=workflow,
         name=name,
         guidance=guidance,
-        phase=phase,
         predecessor=predecessor
     )
     

--- a/mcp_integration/tools.py
+++ b/mcp_integration/tools.py
@@ -804,14 +804,18 @@ async def update_activity(activity_id: int, name: str = None, guidance: str = No
     if update_data:
         from methodology.services.activity_service import ActivityService
         old_version = activity.workflow.playbook.version
-        
-        # Update activity
-        activity = await sync_to_async(ActivityService.update_activity)(activity_id, **update_data)
-        
+
+        try:
+            activity = await sync_to_async(ActivityService.update_activity)(activity_id, **update_data)
+        except ValidationError as e:
+            msg = e.message if hasattr(e, 'message') else str(e)
+            logger.error(f'MCP Tool: update_activity validation error: {msg}')
+            raise ValueError(msg)
+
         # Increment grandparent version
         activity.workflow.playbook.version += Decimal('0.1')
         await sync_to_async(activity.workflow.playbook.save)()
-        
+
         logger.info(f'MCP Tool: Updated activity, grandparent version {old_version} → {activity.workflow.playbook.version}')
     
     return {

--- a/mcp_integration/tools.py
+++ b/mcp_integration/tools.py
@@ -491,14 +491,14 @@ async def delete_workflow(workflow_id: int) -> dict:
 # ============================================================================
 
 async def create_activity(workflow_id: int, name: str, guidance: str = "",
-                        phase: str = None, predecessor_id: int = None) -> dict:
+                        phase_id: int = None, predecessor_id: int = None) -> dict:
     """
     Create activity in workflow (DRAFT playbook). Increments grandparent version.
-    
+
     :param workflow_id: Parent workflow ID. Example: 1
     :param name: Activity name. Example: "Design Component"
     :param guidance: Rich Markdown guidance (optional)
-    :param phase: Phase grouping (optional)
+    :param phase_id: Phase ID to assign (optional, must belong to same playbook). Example: 3
     :param predecessor_id: Predecessor activity ID (optional, must be in same workflow)
     :return: Created activity dict
     :raises PermissionError: if grandparent playbook is released
@@ -539,6 +539,7 @@ async def create_activity(workflow_id: int, name: str, guidance: str = "",
         workflow=workflow,
         name=name,
         guidance=guidance,
+        phase_id=phase_id,
         predecessor=predecessor
     )
     
@@ -552,7 +553,7 @@ async def create_activity(workflow_id: int, name: str, guidance: str = "",
         'id': activity.id,
         'name': activity.name,
         'guidance': activity.guidance,
-        'phase': activity.phase,
+        'phase_id': activity.phase_id,
         'order': activity.order,
         'workflow_id': workflow.id,
         'predecessor_id': predecessor.id if predecessor else None,

--- a/mcp_integration/tools.py
+++ b/mcp_integration/tools.py
@@ -13,6 +13,7 @@ os.environ.setdefault('DJANGO_ALLOW_ASYNC_UNSAFE', 'true')
 import logging
 from typing import Literal, Optional
 from decimal import Decimal
+from django.core.exceptions import ValidationError
 from fastmcp import FastMCP
 from asgiref.sync import sync_to_async
 
@@ -535,14 +536,19 @@ async def create_activity(workflow_id: int, name: str, guidance: str = "",
     # Call existing service
     from methodology.services.activity_service import ActivityService
     old_version = workflow.playbook.version
-    activity = await sync_to_async(ActivityService.create_activity)(
-        workflow=workflow,
-        name=name,
-        guidance=guidance,
-        phase_id=phase_id,
-        predecessor=predecessor
-    )
-    
+    try:
+        activity = await sync_to_async(ActivityService.create_activity)(
+            workflow=workflow,
+            name=name,
+            guidance=guidance,
+            phase_id=phase_id,
+            predecessor=predecessor
+        )
+    except ValidationError as e:
+        msg = e.message if hasattr(e, 'message') else str(e)
+        logger.error(f'MCP Tool: create_activity validation error: {msg}')
+        raise ValueError(msg)
+
     # Increment grandparent version
     workflow.playbook.version += Decimal('0.1')
     await sync_to_async(workflow.playbook.save)()

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -208,6 +208,38 @@ class TestMCPActivityUpdate:
         phase_obj = await sync_to_async(lambda: activity.phase)()
         assert phase_obj.name == 'Inception'
 
+    @pytest.mark.asyncio
+    async def test_update_activity_invalid_phase_id_raises_value_error(self, setup_user_context, activity):
+        """Non-existent phase_id raises ValueError, not a raw Django ValidationError."""
+        with pytest.raises(ValueError, match='Phase'):
+            await update_activity(activity_id=activity.id, phase_id=99999)
+
+    @pytest.mark.asyncio
+    async def test_update_activity_phase_from_different_playbook_raises_value_error(
+        self, setup_user_context, activity, maria
+    ):
+        """phase_id from a different playbook raises ValueError."""
+        other_playbook = await sync_to_async(Playbook.objects.create)(
+            name='Other Playbook', description='', category='test',
+            status='draft', source='owned', author=maria,
+        )
+        other_phase = await sync_to_async(Phase.objects.create)(
+            name='Foreign Phase', playbook=other_playbook, order=1,
+        )
+        with pytest.raises(ValueError, match='Phase'):
+            await update_activity(activity_id=activity.id, phase_id=other_phase.id)
+
+    @pytest.mark.asyncio
+    async def test_update_activity_duplicate_name_raises_value_error(
+        self, setup_user_context, workflow, activity
+    ):
+        """Renaming to an existing activity name in the same workflow raises ValueError."""
+        other = await sync_to_async(Activity.objects.create)(
+            name='Other Activity', workflow=workflow, order=2,
+        )
+        with pytest.raises(ValueError, match='Other Activity'):
+            await update_activity(activity_id=activity.id, name=other.name)
+
 
 @pytest.mark.django_db(transaction=True)
 class TestMCPActivityGet:

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -81,6 +81,8 @@ class TestMCPActivityCreate:
 
         assert result['name'] == 'New Activity'
         assert result['workflow_id'] == workflow.id
+        assert result['order'] == 1
+        assert result['phase_id'] is None
         assert 'id' in result
 
         # Verify persisted in DB
@@ -239,6 +241,22 @@ class TestMCPActivityUpdate:
         )
         with pytest.raises(ValueError, match='Other Activity'):
             await update_activity(activity_id=activity.id, name=other.name)
+
+    @pytest.mark.asyncio
+    async def test_update_activity_released_playbook_raises_permission_error(self, setup_user_context, maria):
+        """Updating activity in a released playbook raises PermissionError."""
+        released = await sync_to_async(Playbook.objects.create)(
+            name='Released Playbook', description='', category='test',
+            status='released', source='owned', author=maria,
+        )
+        wf = await sync_to_async(Workflow.objects.create)(
+            name='Released Workflow', description='', playbook=released, order=1,
+        )
+        act = await sync_to_async(Activity.objects.create)(
+            name='Locked Activity', workflow=wf, order=1,
+        )
+        with pytest.raises(PermissionError, match='released'):
+            await update_activity(activity_id=act.id, name='New Name')
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -92,14 +92,18 @@ class TestMCPActivityCreate:
         assert draft_playbook.version > version_before
 
     @pytest.mark.asyncio
-    async def test_create_activity_phase_param_accepted(self, setup_user_context, workflow):
-        """Passing phase string does not raise an error (param accepted, not wired to DB)."""
+    async def test_create_activity_phase_id_persisted(self, setup_user_context, workflow, phase):
+        """phase_id is wired through to the service and persisted on the activity."""
         result = await create_activity(
             workflow_id=workflow.id,
             name='Phase Activity',
-            phase='Inception',
+            phase_id=phase.id,
         )
         assert result['name'] == 'Phase Activity'
+        assert result['phase_id'] == phase.id
+
+        created = await sync_to_async(Activity.objects.get)(pk=result['id'])
+        assert created.phase_id == phase.id
 
     @pytest.mark.asyncio
     async def test_create_activity_with_predecessor(self, setup_user_context, workflow, activity):

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -8,7 +8,7 @@ from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from methodology.models import Playbook, Workflow, Activity, Phase, Agent, Skill, Artifact, ArtifactInput
 from mcp_integration.context import set_current_user
-from mcp_integration.tools import update_activity, get_activity
+from mcp_integration.tools import create_activity, update_activity, get_activity
 
 User = get_user_model()
 
@@ -66,6 +66,53 @@ def phase(draft_playbook):
         playbook=draft_playbook,
         order=1
     )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestMCPActivityCreate:
+    """Test create_activity MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_activity_happy_path(self, setup_user_context, workflow, draft_playbook):
+        """Create activity returns correct fields and increments playbook version."""
+        version_before = await sync_to_async(lambda: draft_playbook.version)()
+
+        result = await create_activity(workflow_id=workflow.id, name='New Activity')
+
+        assert result['name'] == 'New Activity'
+        assert result['workflow_id'] == workflow.id
+        assert 'id' in result
+
+        # Verify persisted in DB
+        activity = await sync_to_async(Activity.objects.get)(pk=result['id'])
+        assert activity.name == 'New Activity'
+
+        # Playbook version should have incremented
+        await sync_to_async(draft_playbook.refresh_from_db)()
+        assert draft_playbook.version > version_before
+
+    @pytest.mark.asyncio
+    async def test_create_activity_phase_param_accepted(self, setup_user_context, workflow):
+        """Passing phase string does not raise an error (param accepted, not wired to DB)."""
+        result = await create_activity(
+            workflow_id=workflow.id,
+            name='Phase Activity',
+            phase='Inception',
+        )
+        assert result['name'] == 'Phase Activity'
+
+    @pytest.mark.asyncio
+    async def test_create_activity_with_predecessor(self, setup_user_context, workflow, activity):
+        """Predecessor wiring is persisted correctly."""
+        result = await create_activity(
+            workflow_id=workflow.id,
+            name='Follow-up Activity',
+            predecessor_id=activity.id,
+        )
+
+        assert result['name'] == 'Follow-up Activity'
+        follow_up = await sync_to_async(Activity.objects.get)(pk=result['id'])
+        assert follow_up.predecessor_id == activity.id
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -156,6 +156,34 @@ class TestMCPActivityCreate:
                 name=activity.name,
             )
 
+    @pytest.mark.asyncio
+    async def test_create_activity_released_playbook_raises_permission_error(self, setup_user_context, maria):
+        """Creating activity in a released playbook raises PermissionError."""
+        released = await sync_to_async(Playbook.objects.create)(
+            name='Released Playbook', description='', category='test',
+            status='released', source='owned', author=maria,
+        )
+        workflow = await sync_to_async(Workflow.objects.create)(
+            name='Released Workflow', description='', playbook=released, order=1,
+        )
+        with pytest.raises(PermissionError, match='released'):
+            await create_activity(workflow_id=workflow.id, name='Blocked Activity')
+
+    @pytest.mark.asyncio
+    async def test_create_activity_predecessor_in_different_workflow_raises_value_error(
+        self, setup_user_context, draft_playbook, workflow, activity
+    ):
+        """Predecessor from a different workflow raises ValueError."""
+        other_workflow = await sync_to_async(Workflow.objects.create)(
+            name='Other Workflow', description='', playbook=draft_playbook, order=2,
+        )
+        with pytest.raises(ValueError, match=str(activity.id)):
+            await create_activity(
+                workflow_id=other_workflow.id,
+                name='Cross-workflow Activity',
+                predecessor_id=activity.id,
+            )
+
 
 @pytest.mark.django_db(transaction=True)
 class TestMCPActivityUpdate:

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -118,6 +118,44 @@ class TestMCPActivityCreate:
         follow_up = await sync_to_async(Activity.objects.get)(pk=result['id'])
         assert follow_up.predecessor_id == activity.id
 
+    @pytest.mark.asyncio
+    async def test_create_activity_invalid_phase_id_raises_value_error(self, setup_user_context, workflow):
+        """Non-existent phase_id raises ValueError, not a raw Django ValidationError."""
+        with pytest.raises(ValueError, match='Phase'):
+            await create_activity(
+                workflow_id=workflow.id,
+                name='Bad Phase Activity',
+                phase_id=99999,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_activity_phase_from_different_playbook_raises_value_error(
+        self, setup_user_context, workflow, maria
+    ):
+        """phase_id from a different playbook raises ValueError."""
+        other_playbook = await sync_to_async(Playbook.objects.create)(
+            name='Other Playbook', description='', category='test',
+            status='draft', source='owned', author=maria,
+        )
+        other_phase = await sync_to_async(Phase.objects.create)(
+            name='Foreign Phase', playbook=other_playbook, order=1,
+        )
+        with pytest.raises(ValueError, match='Phase'):
+            await create_activity(
+                workflow_id=workflow.id,
+                name='Wrong Phase Activity',
+                phase_id=other_phase.id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_activity_duplicate_name_raises_value_error(self, setup_user_context, workflow, activity):
+        """Duplicate activity name in same workflow raises ValueError."""
+        with pytest.raises(ValueError, match=activity.name):
+            await create_activity(
+                workflow_id=workflow.id,
+                name=activity.name,
+            )
+
 
 @pytest.mark.django_db(transaction=True)
 class TestMCPActivityUpdate:


### PR DESCRIPTION
## Summary

Three compounding problems in the activity MCP tools, all fixed here:

**1. TypeError on every `create_activity` call**
Tool was passing `phase=phase` (str) to `ActivityService.create_activity()`, which only accepts `phase_id` (int). Fixed by removing the invalid kwarg.

**2. `phase` silently dropped on creation**
Replaced `phase: str` with `phase_id: int` in the `create_activity` signature (consistent with `update_activity`) and wired it through to the service. Return dict now includes `phase_id` (int).

**3. Uncaught `ValidationError` in both `create_activity` and `update_activity`**
`ActivityService` raises `django.core.exceptions.ValidationError` for invalid `phase_id`, wrong-playbook phase, and duplicate activity names. These propagated uncaught, surfacing as `['message in brackets']` tracebacks to the AI caller. Now caught and re-raised as clean `ValueError` in both tools. `ValidationError` imported at module level.

## Files changed

- `mcp_integration/tools.py` — signature, service call, error handling, return dict for both tools; `ValidationError` import
- `tests/integration/test_mcp_activity_tools.py` — 12 new tests (3 existing → 15 total)
- `docs/features/act-13-mcp/interact-with-activities-via-mcp.feature` — `create_activity` scenario updated to use `phase_id`

## Tests added (12 new across both tools)

**`TestMCPActivityCreate` (8 new):**
- `test_create_activity_happy_path` — full return dict validated (name, order, phase_id, workflow_id, version increment)
- `test_create_activity_phase_id_persisted`
- `test_create_activity_with_predecessor`
- `test_create_activity_invalid_phase_id_raises_value_error`
- `test_create_activity_phase_from_different_playbook_raises_value_error`
- `test_create_activity_duplicate_name_raises_value_error`
- `test_create_activity_released_playbook_raises_permission_error`
- `test_create_activity_predecessor_in_different_workflow_raises_value_error`

**`TestMCPActivityUpdate` (4 new):**
- `test_update_activity_invalid_phase_id_raises_value_error`
- `test_update_activity_phase_from_different_playbook_raises_value_error`
- `test_update_activity_duplicate_name_raises_value_error`
- `test_update_activity_released_playbook_raises_permission_error`

## Test plan

- [x] `pytest tests/integration/test_mcp_activity_tools.py` — 15 pass (12 new + 3 existing)
- [x] `pytest tests/unit/ tests/integration/` — 684 passed, 0 failures (4 pre-existing errors in `test_mcp_server_acceptance.py` due to hardcoded `.venv` path, unrelated to this PR)
- [x] `create_activity` MCP tool verified working end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)