### PR TITLE
fix(mcp): catch ValidationError in update_activity and re-raise as ValueError

### DIFF
--- a/mcp_integration/tools.py
+++ b/mcp_integration/tools.py
@@ -13,6 +13,7 @@ os.environ.setdefault('DJANGO_ALLOW_ASYNC_UNSAFE', 'true')
 import logging
 from typing import Literal, Optional
 from decimal import Decimal
+from django.core.exceptions import ValidationError
 from fastmcp import FastMCP
 from asgiref.sync import sync_to_async
 
@@ -798,14 +799,18 @@ async def update_activity(activity_id: int, name: str = None, guidance: str = No
     if update_data:
         from methodology.services.activity_service import ActivityService
         old_version = activity.workflow.playbook.version
-        
-        # Update activity
-        activity = await sync_to_async(ActivityService.update_activity)(activity_id, **update_data)
-        
+
+        try:
+            activity = await sync_to_async(ActivityService.update_activity)(activity_id, **update_data)
+        except ValidationError as e:
+            msg = e.message if hasattr(e, 'message') else str(e)
+            logger.error(f'MCP Tool: update_activity validation error: {msg}')
+            raise ValueError(msg)
+
         # Increment grandparent version
         activity.workflow.playbook.version += Decimal('0.1')
         await sync_to_async(activity.workflow.playbook.save)()
-        
+
         logger.info(f'MCP Tool: Updated activity, grandparent version {old_version} → {activity.workflow.playbook.version}')
     
     return {

--- a/tests/integration/test_mcp_activity_tools.py
+++ b/tests/integration/test_mcp_activity_tools.py
@@ -91,6 +91,38 @@ class TestMCPActivityUpdate:
         phase_obj = await sync_to_async(lambda: activity.phase)()
         assert phase_obj.name == 'Inception'
 
+    @pytest.mark.asyncio
+    async def test_update_activity_invalid_phase_id_raises_value_error(self, setup_user_context, activity):
+        """Non-existent phase_id raises ValueError, not a raw Django ValidationError."""
+        with pytest.raises(ValueError, match='Phase'):
+            await update_activity(activity_id=activity.id, phase_id=99999)
+
+    @pytest.mark.asyncio
+    async def test_update_activity_phase_from_different_playbook_raises_value_error(
+        self, setup_user_context, activity, maria
+    ):
+        """phase_id from a different playbook raises ValueError."""
+        other_playbook = await sync_to_async(Playbook.objects.create)(
+            name='Other Playbook', description='', category='test',
+            status='draft', source='owned', author=maria,
+        )
+        other_phase = await sync_to_async(Phase.objects.create)(
+            name='Foreign Phase', playbook=other_playbook, order=1,
+        )
+        with pytest.raises(ValueError, match='Phase'):
+            await update_activity(activity_id=activity.id, phase_id=other_phase.id)
+
+    @pytest.mark.asyncio
+    async def test_update_activity_duplicate_name_raises_value_error(
+        self, setup_user_context, workflow, activity
+    ):
+        """Renaming to an existing activity name in the same workflow raises ValueError."""
+        other = await sync_to_async(Activity.objects.create)(
+            name='Other Activity', workflow=workflow, order=2,
+        )
+        with pytest.raises(ValueError, match='Other Activity'):
+            await update_activity(activity_id=activity.id, name=other.name)
+
 
 @pytest.mark.django_db(transaction=True)
 class TestMCPActivityGet:


### PR DESCRIPTION
## Summary

\`ActivityService.update_activity()\` raises \`django.core.exceptions.ValidationError\` for:
- invalid \`phase_id\` (not found)
- \`phase_id\` from a different playbook
- renaming to a name that already exists in the same workflow

None of these were caught in the MCP tool, so raw internal tracebacks escaped to the AI caller. Now caught and re-raised as \`ValueError\` with a clean message — consistent with the rest of the tool layer and matching the fix applied to \`create_activity\` in PR #76.

Added \`ValidationError\` import at module level (same approach as PR #76).

## Tests added (3 new, written red then green)

- \`test_update_activity_invalid_phase_id_raises_value_error\`
- \`test_update_activity_phase_from_different_playbook_raises_value_error\`
- \`test_update_activity_duplicate_name_raises_value_error\`

## Test plan

- [x] \`pytest tests/integration/test_mcp_activity_tools.py::TestMCPActivityUpdate\` — 4 tests pass (3 new + 1 existing)
- [x] \`pytest tests/unit/ tests/integration/\` — 676 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)