### PR TITLE
fix(mcp): normalize ValidationError across remaining write tools

### DIFF
--- a/docs/features/act-13-mcp/interact-with-activities-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-activities-via-mcp.feature
@@ -70,7 +70,7 @@ Feature: FOB-MCP-ACTIVITIES-1 AI Assistant Interacts with Activities via MCP
       | workflow_id |            1 |
       | name        | Define Props |
       | guidance    | Duplicate    |
-    Then MCP returns error "ValidationError: Activity with name 'Define Props' already exists in this workflow"
+    Then MCP returns error "ValueError: Activity with name 'Define Props' already exists in this workflow"
   # ============================================================================
   # LIST ACTIVITIES
   # ============================================================================
@@ -205,7 +205,7 @@ Feature: FOB-MCP-ACTIVITIES-1 AI Assistant Interacts with Activities via MCP
     When Cascade calls "set_activity_predecessor" with:
       | activity_id    | 1 |
       | predecessor_id | 3 |
-    Then MCP returns error "ValidationError: Circular dependency detected"
+    Then MCP returns error "ValueError: Circular dependency detected"
     And no dependency is created
 
   Scenario: FOB-MCP-CONFIG-ACTIVITIES-UPDATE_ACTIVITY-7 Predecessor in different workflow raises error

--- a/docs/features/act-13-mcp/interact-with-agents-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-agents-via-mcp.feature
@@ -32,7 +32,7 @@ Feature: FOB-MCP-AGENTS-1 AI Assistant Interacts with Agents via MCP
     When Cascade calls MCP tool "create_agent" with:
       | playbook_id | 1 |
       | name        |   |
-    Then MCP returns error "ValidationError: Agent name cannot be empty"
+    Then MCP returns error "ValueError: Agent name cannot be empty"
 
   Scenario: MCP-AG-03 Create agent in released playbook raises error
     Given released playbook "Production Guide" exists for user "maria"
@@ -125,7 +125,7 @@ Feature: FOB-MCP-AGENTS-1 AI Assistant Interacts with Agents via MCP
     When Cascade calls MCP tool "link_agent_to_activity" with:
       | activity_id | 2 |
       | agent_id    | 1 |
-    Then MCP returns error "ValidationError: must be in the same playbook"
+    Then MCP returns error "ValueError: must be in the same playbook"
 
   Scenario: MCP-AG-13 Unlink agent from activity
     Given draft playbook with activity linked to agent "Code Reviewer"

--- a/docs/features/act-13-mcp/interact-with-playbooks-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-playbooks-via-mcp.feature
@@ -37,7 +37,7 @@ Feature: FOB-MCP-PLAYBOOKS-1 AI Assistant Interacts with Playbooks via MCP
       | name        | React Component Development |
       | description | Different description       |
       | category    | frontend                    |
-    Then MCP returns error "ValidationError: Playbook 'React Component Development' already exists"
+    Then MCP returns error "ValueError: Playbook 'React Component Development' already exists"
     And no new playbook is created
 
   Scenario: FOB-MCP-CONFIG-PLAYBOOKS-CREATE_PLAYBOOK-2 Empty name raises error
@@ -45,7 +45,7 @@ Feature: FOB-MCP-PLAYBOOKS-1 AI Assistant Interacts with Playbooks via MCP
       | name        |           |
       | description | Test desc |
       | category    | test      |
-    Then MCP returns error "ValidationError: Playbook name cannot be empty"
+    Then MCP returns error "ValueError: Playbook name cannot be empty"
   # ============================================================================
   # LIST PLAYBOOKS
   # ============================================================================
@@ -153,7 +153,7 @@ Feature: FOB-MCP-PLAYBOOKS-1 AI Assistant Interacts with Playbooks via MCP
     When Cascade calls MCP tool "update_playbook" with:
       | playbook_id |         2 |
       | name        | React Dev |
-    Then MCP returns error "ValidationError: Playbook 'React Dev' already exists"
+    Then MCP returns error "ValueError: Playbook 'React Dev' already exists"
     And playbook id=2 is not modified
   # ============================================================================
   # DELETE PLAYBOOK (DRAFT ONLY)

--- a/docs/features/act-13-mcp/interact-with-skills-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-skills-via-mcp.feature
@@ -36,7 +36,7 @@ Feature: FOB-MCP-SKILLS-1 AI Assistant Interacts with Skills via MCP
     When Cascade calls MCP tool "create_skill" with:
       | playbook_id | 1 |
       | title       |   |
-    Then MCP returns error "ValidationError: Skill title cannot be empty"
+    Then MCP returns error "ValueError: Skill title cannot be empty"
 
   Scenario: MCP-SK-03 Create skill in released playbook raises error
     Given released playbook "Production Guide" exists for user "maria"
@@ -146,7 +146,7 @@ Feature: FOB-MCP-SKILLS-1 AI Assistant Interacts with Skills via MCP
     When Cascade calls MCP tool "link_skill_to_activity" with:
       | activity_id | 2 |
       | skill_id    | 1 |
-    Then MCP returns error "ValidationError: must be in the same playbook"
+    Then MCP returns error "ValueError: must be in the same playbook"
 
   Scenario: MCP-SK-15 Unlink skill from activity
     Given draft playbook with activity linked to skill "Build Login Form"

--- a/docs/features/act-13-mcp/interact-with-workflows-via-mcp.feature
+++ b/docs/features/act-13-mcp/interact-with-workflows-via-mcp.feature
@@ -56,7 +56,7 @@ Feature: FOB-MCP-WORKFLOWS-1 AI Assistant Interacts with Workflows via MCP
       | playbook_id |            1 |
       | name        | Design Phase |
       | description | Duplicate    |
-    Then MCP returns error "ValidationError: Workflow 'Design Phase' already exists in this playbook"
+    Then MCP returns error "ValueError: Workflow 'Design Phase' already exists in this playbook"
 
   Scenario: FOB-MCP-CONFIG-WORKFLOWS-CREATE_WORKFLOW-4 Non-existent playbook raises error
     When Cascade calls "create_workflow" with:
@@ -156,7 +156,7 @@ Feature: FOB-MCP-WORKFLOWS-1 AI Assistant Interacts with Workflows via MCP
     When Cascade calls "update_workflow" with:
       | workflow_id |            2 |
       | name        | Design Phase |
-    Then MCP returns error "ValidationError: Workflow 'Design Phase' already exists in this playbook"
+    Then MCP returns error "ValueError: Workflow 'Design Phase' already exists in this playbook"
   # ============================================================================
   # DELETE WORKFLOW (IN DRAFT PLAYBOOK)
   # ============================================================================

--- a/mcp_integration/tools.py
+++ b/mcp_integration/tools.py
@@ -3,6 +3,17 @@ MCP Tool Definitions for Mimir.
 
 Thin wrappers around existing service layer methods.
 Adds: permission checks, user context, version incrementing.
+
+Exception contract for MCP callers
+---------------------------------
+- ``ValueError``: not found, wrong owner, invalid arguments, and any
+  ``django.core.exceptions.ValidationError`` raised by services (normalized
+  via ``_handle_validation_error``) unless noted otherwise below.
+- ``PermissionError``: attempts to mutate a released playbook (and similar
+  guardrails).
+
+Read-only tools (list/get) typically raise only ``ValueError`` for missing
+entities or wrong ownership. Write tools may raise both.
 """
 import os
 
@@ -25,6 +36,22 @@ mcp = FastMCP("Mimir Methodology Assistant")
 
 # Import user context management
 from mcp_integration.context import get_current_user
+
+
+def _handle_validation_error(e: ValidationError, tool_name: str) -> None:
+    """
+    Normalize Django ValidationError to ValueError for MCP callers.
+
+    :param e: ValidationError from the service layer
+    :param tool_name: MCP tool name for logging
+    :raises ValueError: Always re-raises with the validation message
+    """
+    if hasattr(e, 'messages') and e.messages:
+        msg = '; '.join(str(m) for m in e.messages)
+    else:
+        msg = str(e)
+    logger.error(f'MCP Tool: {tool_name} validation error: {msg}')
+    raise ValueError(msg)
 
 
 # ============================================================================
@@ -61,13 +88,16 @@ async def create_playbook(name: str, description: str, category: str) -> dict:
     
     # Call existing service
     from methodology.services.playbook_service import PlaybookService
-    playbook = await sync_to_async(PlaybookService.create_playbook)(
-        name=name,
-        description=description,
-        category=category,
-        author=user,
-        status='draft'  # MCP always creates drafts
-    )
+    try:
+        playbook = await sync_to_async(PlaybookService.create_playbook)(
+            name=name,
+            description=description,
+            category=category,
+            author=user,
+            status='draft'  # MCP always creates drafts
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_playbook')
     
     result = {
         'id': playbook.id,
@@ -166,7 +196,7 @@ async def update_playbook(playbook_id: int, name: str = None,
     :param category: New category or None
     :return: Updated playbook dict
     :raises PermissionError: if playbook is released
-    :raises ValueError: if not found or not owned
+    :raises ValueError: if not found, not owned, or validation fails (e.g. duplicate name)
     """
     logger.info(f'MCP Tool: update_playbook called - id={playbook_id}')
     
@@ -198,7 +228,10 @@ async def update_playbook(playbook_id: int, name: str = None,
         old_version = playbook.version
         
         # Update playbook
-        playbook = await sync_to_async(PlaybookService.update_playbook)(playbook_id, **update_data)
+        try:
+            playbook = await sync_to_async(PlaybookService.update_playbook)(playbook_id, **update_data)
+        except ValidationError as e:
+            _handle_validation_error(e, 'update_playbook')
         
         # Increment version
         playbook.version += Decimal('0.1')
@@ -285,7 +318,10 @@ async def create_workflow(playbook_id: int, name: str, description: str = "") ->
     # Call existing service
     from methodology.services.workflow_service import WorkflowService
     old_version = playbook.version
-    workflow = await sync_to_async(WorkflowService.create_workflow)(playbook, name, description)
+    try:
+        workflow = await sync_to_async(WorkflowService.create_workflow)(playbook, name, description)
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_workflow')
     
     # Increment parent version
     playbook.version += Decimal('0.1')
@@ -391,7 +427,7 @@ async def update_workflow(workflow_id: int, name: str = None,
     :param order: New order or None
     :return: Updated workflow dict
     :raises PermissionError: if parent playbook is released
-    :raises ValueError: if not found
+    :raises ValueError: if not found or validation fails (e.g. duplicate workflow name)
     """
     logger.info(f'MCP Tool: update_workflow called - id={workflow_id}')
     
@@ -426,7 +462,10 @@ async def update_workflow(workflow_id: int, name: str = None,
         old_version = workflow.playbook.version
         
         # Update workflow
-        workflow = await sync_to_async(WorkflowService.update_workflow)(workflow_id, **update_data)
+        try:
+            workflow = await sync_to_async(WorkflowService.update_workflow)(workflow_id, **update_data)
+        except ValidationError as e:
+            _handle_validation_error(e, 'update_workflow')
         
         # Increment parent version
         workflow.playbook.version += Decimal('0.1')
@@ -545,9 +584,7 @@ async def create_activity(workflow_id: int, name: str, guidance: str = "",
             predecessor=predecessor
         )
     except ValidationError as e:
-        msg = e.message if hasattr(e, 'message') else str(e)
-        logger.error(f'MCP Tool: create_activity validation error: {msg}')
-        raise ValueError(msg)
+        _handle_validation_error(e, 'create_activity')
 
     # Increment grandparent version
     workflow.playbook.version += Decimal('0.1')
@@ -769,7 +806,7 @@ async def update_activity(activity_id: int, name: str = None, guidance: str = No
     :param order: New order or None
     :return: Updated activity dict
     :raises PermissionError: if grandparent playbook is released
-    :raises ValueError: if not found
+    :raises ValueError: if not found or validation fails (duplicate name, invalid phase_id, cross-playbook phase)
     """
     logger.info(f'MCP Tool: update_activity called - id={activity_id}')
     
@@ -808,9 +845,7 @@ async def update_activity(activity_id: int, name: str = None, guidance: str = No
         try:
             activity = await sync_to_async(ActivityService.update_activity)(activity_id, **update_data)
         except ValidationError as e:
-            msg = e.message if hasattr(e, 'message') else str(e)
-            logger.error(f'MCP Tool: update_activity validation error: {msg}')
-            raise ValueError(msg)
+            _handle_validation_error(e, 'update_activity')
 
         # Increment grandparent version
         activity.workflow.playbook.version += Decimal('0.1')
@@ -904,7 +939,10 @@ async def set_predecessor(activity_id: int, predecessor_id: int) -> dict:
     # Call service (validates circular dependencies)
     from methodology.services.activity_service import ActivityService
     old_version = activity.workflow.playbook.version
-    await sync_to_async(ActivityService.set_predecessor)(activity, predecessor)
+    try:
+        await sync_to_async(ActivityService.set_predecessor)(activity, predecessor)
+    except ValidationError as e:
+        _handle_validation_error(e, 'set_predecessor')
     
     # Increment grandparent version
     activity.workflow.playbook.version += Decimal('0.1')
@@ -974,18 +1012,24 @@ async def import_workflow_from_local(
     user = await sync_to_async(get_current_user)()
     
     from methodology.services.workflow_import_service import WorkflowImportService
-    result = await sync_to_async(WorkflowImportService.import_workflow_from_markdown)(
-        workflow_id=workflow_id,
-        source_directory=source_directory
-    )
+    try:
+        result = await sync_to_async(WorkflowImportService.import_workflow_from_markdown)(
+            workflow_id=workflow_id,
+            source_directory=source_directory
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'import_workflow_from_local')
     
     if auto_apply and result['playbook_status'] == 'draft':
         from methodology.services.workflow_protocol_service import WorkflowProtocolService
         import os
         protocol_file = os.path.join(source_directory, '_Upload_Protocol.md')
-        apply_result = await sync_to_async(WorkflowProtocolService.apply_upload_protocol)(
-            protocol_file=protocol_file
-        )
+        try:
+            apply_result = await sync_to_async(WorkflowProtocolService.apply_upload_protocol)(
+                protocol_file=protocol_file
+            )
+        except ValidationError as e:
+            _handle_validation_error(e, 'import_workflow_from_local')
         result['auto_applied'] = True
         result['apply_result'] = apply_result
     
@@ -1005,9 +1049,12 @@ async def apply_upload_protocol(protocol_file: str) -> dict:
     user = await sync_to_async(get_current_user)()
     
     from methodology.services.workflow_protocol_service import WorkflowProtocolService
-    result = await sync_to_async(WorkflowProtocolService.apply_upload_protocol)(
-        protocol_file=protocol_file
-    )
+    try:
+        result = await sync_to_async(WorkflowProtocolService.apply_upload_protocol)(
+            protocol_file=protocol_file
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'apply_upload_protocol')
     
     logger.info(f'MCP Tool: Applied protocol, changes: {result["changes_applied"]}')
     return result
@@ -1026,10 +1073,13 @@ async def create_pip_from_protocol(protocol_file: str, pip_title: str) -> dict:
     user = await sync_to_async(get_current_user)()
     
     from methodology.services.workflow_protocol_service import WorkflowProtocolService
-    result = await sync_to_async(WorkflowProtocolService.create_pip_from_protocol)(
-        protocol_file=protocol_file,
-        pip_title=pip_title
-    )
+    try:
+        result = await sync_to_async(WorkflowProtocolService.create_pip_from_protocol)(
+            protocol_file=protocol_file,
+            pip_title=pip_title
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_pip_from_protocol')
     
     logger.info(f'MCP Tool: Created PIP {result["pip_id"]}')
     return result
@@ -1063,13 +1113,16 @@ async def create_skill(
     playbook = await _get_draft_playbook(playbook_id, user)
 
     from methodology.services.skill_service import SkillService
-    skill = await sync_to_async(SkillService.create_skill)(
-        playbook=playbook,
-        title=title,
-        content=content,
-        capability_domain=capability_domain,
-        technology_stack=technology_stack,
-    )
+    try:
+        skill = await sync_to_async(SkillService.create_skill)(
+            playbook=playbook,
+            title=title,
+            content=content,
+            capability_domain=capability_domain,
+            technology_stack=technology_stack,
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_skill')
 
     old_version = playbook.version
     playbook.version += Decimal('0.1')
@@ -1212,7 +1265,10 @@ async def update_skill(
     if technology_stack is not None:
         kwargs['technology_stack'] = technology_stack
 
-    updated = await sync_to_async(SkillService.update_skill)(skill_id, **kwargs)
+    try:
+        updated = await sync_to_async(SkillService.update_skill)(skill_id, **kwargs)
+    except ValidationError as e:
+        _handle_validation_error(e, 'update_skill')
 
     old_version = skill.playbook.version
     skill.playbook.version += Decimal('0.1')
@@ -1286,7 +1342,10 @@ async def link_skill_to_activity(activity_id: int, skill_id: int) -> dict:
     if activity.workflow.playbook.status == 'released':
         raise PermissionError(f'Cannot modify released playbook.')
 
-    updated = await sync_to_async(ActivityService.set_activity_skill)(activity_id, skill_id)
+    try:
+        updated = await sync_to_async(ActivityService.set_activity_skill)(activity_id, skill_id)
+    except ValidationError as e:
+        _handle_validation_error(e, 'link_skill_to_activity')
 
     return {'activity_id': updated.id, 'skill_id': updated.skill_id}
 
@@ -1337,13 +1396,16 @@ async def create_rule(
 
     from methodology.services.rule_service import RuleService
 
-    rule = await sync_to_async(RuleService.create_rule)(
-        playbook=playbook,
-        title=title,
-        content=content,
-        slug=slug,
-        always_apply=always_apply,
-    )
+    try:
+        rule = await sync_to_async(RuleService.create_rule)(
+            playbook=playbook,
+            title=title,
+            content=content,
+            slug=slug,
+            always_apply=always_apply,
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_rule')
     old_version = playbook.version
     playbook.version += Decimal('0.1')
     await sync_to_async(playbook.save)()
@@ -1448,7 +1510,10 @@ async def update_rule(
     if not kwargs:
         raise ValueError('No fields to update')
 
-    updated = await sync_to_async(RuleService.update_rule)(rule_id, **kwargs)
+    try:
+        updated = await sync_to_async(RuleService.update_rule)(rule_id, **kwargs)
+    except ValidationError as e:
+        _handle_validation_error(e, 'update_rule')
     playbook = rule.playbook
     old_version = playbook.version
     playbook.version += Decimal('0.1')
@@ -1503,7 +1568,10 @@ async def set_activity_rules(activity_id: int, rule_ids: list) -> dict:
     if activity.workflow.playbook.status == 'released':
         raise PermissionError('Cannot modify released playbook.')
 
-    await sync_to_async(ActivityService.set_activity_rules)(activity_id, rule_ids)
+    try:
+        await sync_to_async(ActivityService.set_activity_rules)(activity_id, rule_ids)
+    except ValidationError as e:
+        _handle_validation_error(e, 'set_activity_rules')
     updated = await sync_to_async(Activity.objects.prefetch_related('rules').get)(pk=activity_id)
     ids = await sync_to_async(lambda: list(updated.rules.values_list('id', flat=True)))()
     return {'activity_id': activity_id, 'rule_ids': ids}
@@ -1534,11 +1602,14 @@ async def create_agent(
     playbook = await _get_draft_playbook(playbook_id, user)
 
     from methodology.services.agent_service import AgentService
-    agent = await sync_to_async(AgentService.create_agent)(
-        playbook=playbook,
-        name=name,
-        description=description,
-    )
+    try:
+        agent = await sync_to_async(AgentService.create_agent)(
+            playbook=playbook,
+            name=name,
+            description=description,
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_agent')
 
     old_version = playbook.version
     playbook.version += Decimal('0.1')
@@ -1665,7 +1736,10 @@ async def update_agent(
     if description is not None:
         kwargs['description'] = description
 
-    updated = await sync_to_async(AgentService.update_agent)(agent_id, **kwargs)
+    try:
+        updated = await sync_to_async(AgentService.update_agent)(agent_id, **kwargs)
+    except ValidationError as e:
+        _handle_validation_error(e, 'update_agent')
 
     old_version = agent.playbook.version
     agent.playbook.version += Decimal('0.1')
@@ -1737,7 +1811,10 @@ async def link_agent_to_activity(activity_id: int, agent_id: int) -> dict:
     if activity.workflow.playbook.status == 'released':
         raise PermissionError(f'Cannot modify released playbook.')
 
-    updated = await sync_to_async(ActivityService.set_activity_agent)(activity_id, agent_id)
+    try:
+        updated = await sync_to_async(ActivityService.set_activity_agent)(activity_id, agent_id)
+    except ValidationError as e:
+        _handle_validation_error(e, 'link_agent_to_activity')
 
     return {'activity_id': updated.id, 'agent_id': updated.agent_id}
 
@@ -1794,8 +1871,7 @@ async def create_artifact(
     :param is_required: Whether required. Example: True
     :return: Created artifact dict
     :raises PermissionError: If playbook is released
-    :raises ValueError: If playbook or activity not found
-    :raises ValidationError: If validation fails
+    :raises ValueError: If playbook or activity not found, or validation fails
     """
     logger.info(
         f'MCP Tool: create_artifact called - playbook_id={playbook_id}, '
@@ -1816,14 +1892,17 @@ async def create_artifact(
         )
 
     from methodology.services.artifact_service import ArtifactService
-    artifact = await sync_to_async(ArtifactService.create_artifact)(
-        playbook=playbook,
-        produced_by=produced_by,
-        name=name,
-        description=description,
-        type=type,
-        is_required=is_required,
-    )
+    try:
+        artifact = await sync_to_async(ArtifactService.create_artifact)(
+            playbook=playbook,
+            produced_by=produced_by,
+            name=name,
+            description=description,
+            type=type,
+            is_required=is_required,
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_artifact')
 
     old_version = playbook.version
     playbook.version += Decimal('0.1')
@@ -1959,7 +2038,7 @@ async def update_artifact(
     :param is_required: New required flag or None
     :return: Updated artifact dict
     :raises PermissionError: If playbook is released
-    :raises ValueError: If not found
+    :raises ValueError: If not found or validation fails
     """
     logger.info(f'MCP Tool: update_artifact called - artifact_id={artifact_id}')
 
@@ -1991,9 +2070,12 @@ async def update_artifact(
         kwargs['is_required'] = is_required
 
     from methodology.services.artifact_service import ArtifactService
-    updated = await sync_to_async(ArtifactService.update_artifact)(
-        artifact_id, **kwargs,
-    )
+    try:
+        updated = await sync_to_async(ArtifactService.update_artifact)(
+            artifact_id, **kwargs,
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'update_artifact')
 
     playbook = artifact.playbook
     old_version = playbook.version
@@ -2077,8 +2159,7 @@ async def link_artifact_to_activity(
     :param activity_id: Consumer activity ID. Example: 5
     :param is_required: Whether input is required. Example: True
     :return: Dict with id, artifact_id, activity_id, is_required
-    :raises ValueError: If not found
-    :raises ValidationError: If circular dependency or duplicate
+    :raises ValueError: If not found, circular dependency, or duplicate link
     """
     logger.info(
         f'MCP Tool: link_artifact_to_activity called - '
@@ -2111,11 +2192,14 @@ async def link_artifact_to_activity(
         )
 
     from methodology.services.artifact_service import ArtifactService
-    artifact_input = await sync_to_async(ArtifactService.add_artifact_input)(
-        artifact=artifact,
-        activity=activity,
-        is_required=is_required,
-    )
+    try:
+        artifact_input = await sync_to_async(ArtifactService.add_artifact_input)(
+            artifact=artifact,
+            activity=activity,
+            is_required=is_required,
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'link_artifact_to_activity')
 
     logger.info(
         f'MCP Tool: Linked artifact {artifact_id} to activity {activity_id}'
@@ -2213,13 +2297,16 @@ async def create_phase(
         raise PermissionError('Cannot create phases in released playbook')
     
     from methodology.services.phase_service import PhaseService
-    phase = await sync_to_async(PhaseService.create_phase)(
-        playbook_id=playbook_id,
-        name=name,
-        description=description,
-        order=order,
-        user=user
-    )
+    try:
+        phase = await sync_to_async(PhaseService.create_phase)(
+            playbook_id=playbook_id,
+            name=name,
+            description=description,
+            order=order,
+            user=user
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'create_phase')
     
     phase_dict = _phase_to_dict(phase)
     logger.info(f'MCP Tool: Phase {phase_dict["id"]} created in playbook {playbook_id}')
@@ -2330,13 +2417,16 @@ async def update_phase(
         raise PermissionError('Cannot update phases in released playbook')
     
     from methodology.services.phase_service import PhaseService
-    updated_phase = await sync_to_async(PhaseService.update_phase)(
-        phase_id=phase_id,
-        name=name,
-        description=description,
-        order=order,
-        user=user
-    )
+    try:
+        updated_phase = await sync_to_async(PhaseService.update_phase)(
+            phase_id=phase_id,
+            name=name,
+            description=description,
+            order=order,
+            user=user
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'update_phase')
     
     phase_dict = _phase_to_dict(updated_phase)
     logger.info(f'MCP Tool: Phase {phase_id} updated')
@@ -2371,7 +2461,10 @@ async def delete_phase(phase_id: int) -> dict:
         raise PermissionError('Cannot delete phases in released playbook')
     
     from methodology.services.phase_service import PhaseService
-    await sync_to_async(PhaseService.delete_phase)(phase_id, user)
+    try:
+        await sync_to_async(PhaseService.delete_phase)(phase_id, user)
+    except ValidationError as e:
+        _handle_validation_error(e, 'delete_phase')
     
     logger.info(f'MCP Tool: Phase {phase_id} deleted')
     return {'deleted': True}
@@ -2405,11 +2498,14 @@ async def reorder_phases(playbook_id: int, phase_order: list[int]) -> dict:
     from methodology.services.phase_service import PhaseService
     # Convert list of IDs to list of (id, order) tuples
     phase_order_list = [(phase_id, idx + 1) for idx, phase_id in enumerate(phase_order)]
-    updated_phases = await sync_to_async(PhaseService.reorder_phases)(
-        playbook_id=playbook_id,
-        phase_order_list=phase_order_list,
-        user=user
-    )
+    try:
+        updated_phases = await sync_to_async(PhaseService.reorder_phases)(
+            playbook_id=playbook_id,
+            phase_order_list=phase_order_list,
+            user=user
+        )
+    except ValidationError as e:
+        _handle_validation_error(e, 'reorder_phases')
     
     result = {
         'reordered': True,

--- a/tests/e2e/test_auth_login.py
+++ b/tests/e2e/test_auth_login.py
@@ -5,9 +5,35 @@ from a real browser perspective, ensuring the full stack works correctly.
 
 IMPORTANT: These tests run in SYNC mode (not async) to avoid
 pytest-asyncio conflicts with Django ORM operations.
+
+MCP integration tests use ``django_db(transaction=True)``, which flushes the DB
+between tests and removes the ``admin`` user from session ``e2e_seed`` loaddata.
+Re-seed credentials before the happy-path login so a full ``pytest tests/ tests/e2e/`` run stays green.
 """
 import pytest
+from django.contrib.auth import get_user_model
 from playwright.sync_api import Page
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_login_user(db):
+    """Ensure admin / admin123 exists after TransactionTestCase-style integration tests."""
+    user, _ = User.objects.get_or_create(
+        username='admin',
+        defaults={
+            'email': 'admin@example.com',
+            'is_staff': True,
+            'is_superuser': True,
+        },
+    )
+    user.email = 'admin@example.com'
+    user.is_staff = True
+    user.is_superuser = True
+    user.set_password('admin123')
+    user.save()
+    return user
 
 
 @pytest.mark.e2e
@@ -15,7 +41,7 @@ from playwright.sync_api import Page
 class TestLoginE2E:
     """End-to-end tests for user login using Playwright."""
     
-    def test_login_with_valid_credentials_success(self, page: Page, live_server_url: str):
+    def test_login_with_valid_credentials_success(self, page: Page, live_server_url: str, admin_login_user):
         """
         Test E2E-AUTH-01: User can log in with valid credentials.
         

--- a/tests/e2e/test_journey_global_search.py
+++ b/tests/e2e/test_journey_global_search.py
@@ -1,6 +1,44 @@
 """User Journey Certification Test for NAV-06 Global Search."""
 import pytest
+from django.contrib.auth import get_user_model
 from playwright.sync_api import expect
+
+from methodology.models import Activity, Playbook, Workflow
+
+User = get_user_model()
+
+
+@pytest.fixture
+def nav06_sample_data(transactional_db):
+    """Same searchable sample as tests/integration/test_global_search.py (NAV-06)."""
+    user = User.objects.create_user(
+        username='nav06_user',
+        email='nav06@example.com',
+        password='testpass123',
+    )
+    playbook = Playbook.objects.create(
+        name='Component Development Playbook',
+        description='Playbook for components',
+        category='development',
+        author=user,
+    )
+    workflow = Workflow.objects.create(
+        playbook=playbook,
+        name='Component Workflow',
+        description='Workflow for components',
+        order=1,
+    )
+    Activity.objects.create(
+        workflow=workflow,
+        name='Create Component',
+        guidance='Do component work',
+        order=1,
+    )
+    return {
+        'username': 'nav06_user',
+        'password': 'testpass123',
+        'playbook_name': 'Component Development Playbook',
+    }
 
 
 @pytest.mark.e2e
@@ -17,13 +55,10 @@ def test_complete_global_search_journey(page, live_server, nav06_sample_data):
     search_input = page.get_by_test_id('global-search-input')
     expect(search_input).to_be_visible()
     
-    # Type in search
+    # Type in search (HTMX listens for keyup, not programmatic fill alone)
     search_input.fill('Component')
-    page.wait_for_timeout(500)
-    
-    # Verify suggestions appear
-    suggestions = page.locator('#global-search-suggestions-container')
-    expect(suggestions).to_be_visible()
+    search_input.dispatch_event('keyup')
+    expect(page.get_by_test_id('global-search-suggestions')).to_be_visible(timeout=10_000)
     
     # Submit search
     search_input.press('Enter')

--- a/tests/integration/test_mcp_agent_tools.py
+++ b/tests/integration/test_mcp_agent_tools.py
@@ -8,7 +8,6 @@ import pytest
 from decimal import Decimal
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from methodology.models import Playbook, Workflow, Activity, Agent
 from mcp_integration.context import set_current_user
 from mcp_integration.tools import (
@@ -94,7 +93,7 @@ class TestMCPAgentCreate:
     @pytest.mark.asyncio
     async def test_mcp_ag_02_empty_name_raises(self, setup_user_context, draft_playbook):
         """Scenario: MCP-AG-02 Create agent with empty name raises error."""
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             await create_agent(playbook_id=draft_playbook.id, name='')
 
     @pytest.mark.asyncio
@@ -176,6 +175,16 @@ class TestMCPAgentUpdate:
         assert draft_playbook.version == old_version + Decimal('0.1')
 
     @pytest.mark.asyncio
+    async def test_mcp_ag_07b_update_agent_duplicate_name_raises_value_error(
+        self, setup_user_context, draft_playbook,
+    ):
+        """Renaming an agent to an existing name in the same playbook raises ValueError."""
+        a = await create_agent(playbook_id=draft_playbook.id, name='Agent A')
+        b = await create_agent(playbook_id=draft_playbook.id, name='Agent B')
+        with pytest.raises(ValueError, match='Agent B'):
+            await update_agent(agent_id=a['id'], name='Agent B')
+
+    @pytest.mark.asyncio
     async def test_mcp_ag_08_update_released_raises(self, setup_user_context, released_playbook):
         """Scenario: MCP-AG-08 Update agent in released playbook raises error."""
         agent = await sync_to_async(Agent.objects.create)(
@@ -249,7 +258,7 @@ class TestMCPAgentLinkUnlink:
         )
         created = await create_agent(playbook_id=draft_playbook.id, name='AG1')
 
-        with pytest.raises(ValidationError, match='same playbook'):
+        with pytest.raises(ValueError, match='same playbook'):
             await link_agent_to_activity(other_act.id, created['id'])
 
     @pytest.mark.asyncio

--- a/tests/integration/test_mcp_artifact_tools.py
+++ b/tests/integration/test_mcp_artifact_tools.py
@@ -8,7 +8,6 @@ import pytest
 from decimal import Decimal
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from methodology.models import Playbook, Workflow, Activity, Artifact, ArtifactInput
 from mcp_integration.context import set_current_user
 from mcp_integration.tools import (
@@ -122,10 +121,10 @@ class TestMCPArtifactCreate:
         """
         GIVEN a draft playbook
         WHEN create_artifact is called with empty name
-        THEN ValidationError is raised
+        THEN ValueError is raised
         """
         wf, act1, act2 = workflow_with_activities
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             await create_artifact(
                 playbook_id=draft_playbook.id,
                 produced_by_id=act1.id,
@@ -290,6 +289,25 @@ class TestMCPArtifactUpdate:
         assert draft_playbook.version == old_version + Decimal('0.1')
 
     @pytest.mark.asyncio
+    async def test_mcp_ar_08b_update_artifact_duplicate_name_raises_value_error(
+        self, setup_user_context, draft_playbook, workflow_with_activities,
+    ):
+        """Renaming an artifact to an existing name in the same playbook raises ValueError."""
+        wf, act1, act2 = workflow_with_activities
+        first = await create_artifact(
+            playbook_id=draft_playbook.id,
+            produced_by_id=act1.id,
+            name='First Artifact',
+        )
+        await create_artifact(
+            playbook_id=draft_playbook.id,
+            produced_by_id=act1.id,
+            name='Second Artifact',
+        )
+        with pytest.raises(ValueError, match='Second Artifact'):
+            await update_artifact(artifact_id=first['id'], name='Second Artifact')
+
+    @pytest.mark.asyncio
     async def test_mcp_ar_09_update_released_raises(
         self, setup_user_context, released_playbook,
     ):
@@ -416,7 +434,7 @@ class TestMCPArtifactLinkUnlink:
         """
         GIVEN an artifact produced by act1
         WHEN link_artifact_to_activity is called with act1 (the producer)
-        THEN ValidationError is raised (circular dependency)
+        THEN ValueError is raised (circular dependency)
         """
         wf, act1, act2 = workflow_with_activities
         created = await create_artifact(
@@ -425,7 +443,7 @@ class TestMCPArtifactLinkUnlink:
             name='AR1',
         )
 
-        with pytest.raises(ValidationError, match='[Cc]ircular'):
+        with pytest.raises(ValueError, match='[Cc]ircular'):
             await link_artifact_to_activity(
                 artifact_id=created['id'],
                 activity_id=act1.id,
@@ -438,7 +456,7 @@ class TestMCPArtifactLinkUnlink:
         """
         GIVEN an artifact already linked to act2
         WHEN link_artifact_to_activity is called again for act2
-        THEN ValidationError is raised
+        THEN ValueError is raised
         """
         wf, act1, act2 = workflow_with_activities
         created = await create_artifact(
@@ -451,7 +469,7 @@ class TestMCPArtifactLinkUnlink:
             activity_id=act2.id,
         )
 
-        with pytest.raises(ValidationError, match='already'):
+        with pytest.raises(ValueError, match='already'):
             await link_artifact_to_activity(
                 artifact_id=created['id'],
                 activity_id=act2.id,

--- a/tests/integration/test_mcp_phase_tools.py
+++ b/tests/integration/test_mcp_phase_tools.py
@@ -73,7 +73,7 @@ class TestMCPPhaseCreate:
         """Create phase with duplicate name raises error."""
         await create_phase(playbook_id=test_playbook['id'], name="Inception", description="First", order=1)
         
-        with pytest.raises(Exception):  # ValidationError
+        with pytest.raises(ValueError, match='Inception'):
             await create_phase(playbook_id=test_playbook['id'], name="Inception", description="Duplicate", order=2)
 
 

--- a/tests/integration/test_mcp_playbook_tools.py
+++ b/tests/integration/test_mcp_playbook_tools.py
@@ -8,7 +8,6 @@ import pytest
 from decimal import Decimal
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from methodology.models import Playbook
 from mcp_integration.context import set_current_user
 from mcp_integration.tools import (
@@ -67,7 +66,7 @@ class TestMCPPlaybookCreate:
         """Scenario: MCP-PB-02 Create playbook with duplicate name raises error"""
         await create_playbook(name="React Component Development", description="Test", category="frontend")
         
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             await create_playbook(name="React Component Development", description="Different", category="frontend")
 
 
@@ -85,6 +84,14 @@ class TestMCPPlaybookUpdate:
         assert result['name'] == "Updated Name"
         assert result['version'] == '0.2'
         # Version incremented
+
+    @pytest.mark.asyncio
+    async def test_mcp_pb_11_update_playbook_duplicate_name_raises_value_error(self, setup_user_context):
+        """Renaming a playbook to an existing name raises ValueError."""
+        first = await create_playbook(name='Alpha Playbook', description='a', category='test')
+        await create_playbook(name='Beta Playbook', description='b', category='test')
+        with pytest.raises(ValueError, match='Beta'):
+            await update_playbook(playbook_id=first['id'], name='Beta Playbook')
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/integration/test_mcp_skill_tools.py
+++ b/tests/integration/test_mcp_skill_tools.py
@@ -8,7 +8,6 @@ import pytest
 from decimal import Decimal
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from methodology.models import Playbook, Workflow, Activity, Skill
 from mcp_integration.context import set_current_user
 from mcp_integration.tools import (
@@ -98,7 +97,7 @@ class TestMCPSkillCreate:
     @pytest.mark.asyncio
     async def test_mcp_sk_02_empty_title_raises(self, setup_user_context, draft_playbook):
         """Scenario: MCP-SK-02 Create skill with empty title raises error."""
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             await create_skill(playbook_id=draft_playbook.id, title='')
 
     @pytest.mark.asyncio
@@ -204,6 +203,15 @@ class TestMCPSkillUpdate:
         assert draft_playbook.version == old_version + Decimal('0.1')
 
     @pytest.mark.asyncio
+    async def test_mcp_sk_09b_update_skill_empty_title_raises_value_error(
+        self, setup_user_context, draft_playbook,
+    ):
+        """Updating a skill to an empty title raises ValueError (service ValidationError normalized)."""
+        created = await create_skill(playbook_id=draft_playbook.id, title='Valid Title')
+        with pytest.raises(ValueError, match='title'):
+            await update_skill(skill_id=created['id'], title='')
+
+    @pytest.mark.asyncio
     async def test_mcp_sk_10_update_released_raises(self, setup_user_context, released_playbook):
         """Scenario: MCP-SK-10 Update skill in released playbook raises error."""
         skill = await sync_to_async(Skill.objects.create)(
@@ -279,7 +287,7 @@ class TestMCPSkillLinkUnlink:
         )
         created = await create_skill(playbook_id=draft_playbook.id, title='SK1')
 
-        with pytest.raises(ValidationError, match='same playbook'):
+        with pytest.raises(ValueError, match='same playbook'):
             await link_skill_to_activity(other_act.id, created['id'])
 
     @pytest.mark.asyncio

--- a/tests/integration/test_mcp_workflow_tools.py
+++ b/tests/integration/test_mcp_workflow_tools.py
@@ -4,7 +4,6 @@ import pytest_asyncio
 from decimal import Decimal
 from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from methodology.models import Playbook, Workflow
 from mcp_integration.context import set_current_user
 from mcp_integration.tools import create_playbook, create_workflow, update_workflow, delete_workflow
@@ -39,11 +38,28 @@ class TestMCPWorkflowCreate:
     
     @pytest.mark.asyncio
     async def test_mcp_wf_02_create_workflow_duplicate_name_raises_error(self, setup_user_context, draft_playbook):
-        """Scenario: MCP-WF-02 Duplicate workflow name raises ValidationError"""
+        """Scenario: MCP-WF-02 Duplicate workflow name raises ValueError"""
         await create_workflow(playbook_id=draft_playbook['id'], name="Design Phase", description="Test")
         
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             await create_workflow(playbook_id=draft_playbook['id'], name="Design Phase", description="Different")
+
+@pytest.mark.django_db(transaction=True)
+class TestMCPWorkflowUpdate:
+    @pytest.mark.asyncio
+    async def test_mcp_wf_11_update_workflow_duplicate_name_raises_value_error(
+        self, setup_user_context, draft_playbook,
+    ):
+        """Renaming a workflow to an existing name in the same playbook raises ValueError."""
+        wf1 = await create_workflow(
+            playbook_id=draft_playbook['id'], name='First', description='a',
+        )
+        await create_workflow(
+            playbook_id=draft_playbook['id'], name='Second', description='b',
+        )
+        with pytest.raises(ValueError, match='Second'):
+            await update_workflow(workflow_id=wf1['id'], name='Second')
+
 
 @pytest.mark.django_db(transaction=True)
 class TestMCPWorkflowDelete:


### PR DESCRIPTION
Follow-up to #76: applies `_handle_validation_error` to playbook, workflow, skill, agent, artifact, phase, rule, link, import/protocol, and related MCP write paths so Django `ValidationError` is consistently surfaced as `ValueError`. Updates act-13-mcp feature specs and integration tests (exception types and duplicate-name cases).

Made with [Cursor](https://cursor.com)