### PR TITLE
docs(import-export): complete BDD spec for playbook JSON export/import and cross-instance migration

### DIFF
--- a/docs/features/act-10-import-export/import-export.feature
+++ b/docs/features/act-10-import-export/import-export.feature
@@ -1,41 +1,353 @@
 Feature: FOB-IMPORT-EXPORT-1 Import and Export Playbooks
   As a methodology author (Maria)
-  I want to import and export playbooks
-  So that I can share and backup my work
+  I want to export a playbook as a self-contained JSON file and import it on any Mimir instance
+  So that I can move playbooks between environments without sharing a database
+
+  # PRIMARY USE CASE — Cross-Instance Migration
+  # Maria runs Mimir on two machines: a dev instance (laptop) and a shared team instance.
+  # She builds a playbook on the dev instance and wants it on the team instance.
+  # The only connection between the two is a file she can copy.
+  # The exported JSON must be fully self-contained — importing it on a fresh Mimir instance
+  # with an empty database must produce an identical, fully functional playbook.
+  # No IDs, no DB state, no user accounts transfer. Only the content transfers.
+
+  Status: 🔲 NOT STARTED
+  Branch: feature/import-export
+  Related: act-3-workflows (MCP-level export/import — see workflows-export-import.feature)
+
+  # JSON EXPORT SCHEMA
+  # A valid export file has the following top-level structure:
+  #
+  # {
+  #   "mimir_version": "1.0",
+  #   "exported_at": "<ISO8601>",
+  #   "playbook": {
+  #     "name": "...", "description": "...", "category": "...",
+  #     "tags": [...], "visibility": "...", "status": "...", "version": "...",
+  #     "phases":    [{ "ref": "phase-1", "name": "...", "description": "...", "order": 1 }],
+  #     "agents":    [{ "ref": "agent-1", "name": "...", "description": "..." }],
+  #     "skills":    [{ "ref": "skill-1", "title": "...", "capability_domain": "...",
+  #                     "technology_stack": "...", "content": "..." }],
+  #     "rules":     [{ "ref": "rule-1", "title": "...", "slug": "...",
+  #                     "content": "...", "always_apply": true }],
+  #     "workflows": [{
+  #       "ref": "workflow-1", "name": "...", "description": "...",
+  #       "abbreviation": "...", "order": 1,
+  #       "activities": [{
+  #         "ref": "activity-1", "name": "...", "guidance": "...", "order": 1,
+  #         "phase_ref": "phase-1" | null,
+  #         "predecessor_ref": "activity-N" | null,
+  #         "agent_ref": "agent-1" | null,
+  #         "skill_ref": "skill-1" | null,
+  #         "rules": ["rule-1", "rule-2"],
+  #         "artifacts_consumed": [{ "artifact_ref": "artifact-2", "is_required": true }]
+  #       }]
+  #     }],
+  #     "artifacts": [{
+  #       "ref": "artifact-1", "name": "...", "description": "...",
+  #       "type": "...", "is_required": true,
+  #       "produced_by_ref": "activity-1"
+  #     }]
+  #   }
+  # }
+  #
+  # IMPORTANT: "ref" values are stable string identifiers within the export file.
+  # They are NOT database PKs. They survive re-import with new PKs.
+  # Fields excluded from export: id, source, author, created_at, updated_at.
+  # status and version are preserved from the source — an imported released v1.2 playbook
+  # arrives as released v1.2. The importing user becomes the author on the new instance.
 
   Background:
     Given Maria is authenticated in FOB
+    And Maria owns draft playbook "React Frontend Dev" (version=0.3)
+    And the playbook has:
+      | entity     | count |
+      | workflows  |     2 |
+      | activities |     6 |
+      | agents     |     1 |
+      | skills     |     2 |
+      | phases     |     1 |
+      | rules      |     3 |
+      | artifacts  |     2 |
+    And activity "Create Mockup" has predecessor "Define Props"
+    And activity "Implement Component" is linked to agent "Code Reviewer",
+        skill "React Dev", phase "Execution", and rules "pytest-first" and "ruff-format"
+    And artifact "Design Spec" is produced by "Define Props" and consumed by "Implement Component"
+    And artifact "Component Code" is produced by "Implement Component"
 
-  Scenario: FOB-IMPORT-01 Export playbook as JSON
-    Given Maria is viewing a playbook
-    When she clicks [Export] > [Export as JSON]
-    Then playbook is downloaded as .json file
-    And the file contains complete playbook structure
+  # ============================================================================
+  # EXPORT
+  # ============================================================================
 
-  Scenario: FOB-IMPORT-02 Export playbook as MPA
-    Given Maria is viewing a playbook
-    When she clicks [Export] > [Export as .mpa]
-    Then playbook is packaged as .mpa file
-    And it includes all workflows, activities, artifacts
+  Scenario: FOB-IMPORT-EXPORT-1-01 Export triggers JSON download
+    Given Maria is viewing "React Frontend Dev" playbook detail page
+    When she clicks the [Export as JSON] button (data-testid="export-playbook-json")
+    Then the browser downloads "react-frontend-dev.json"
+    And the response has Content-Type "application/json"
+    And the response has Content-Disposition header containing "react-frontend-dev.json"
 
-  Scenario: FOB-IMPORT-03 Import playbook from JSON
-    Given Maria is on playbooks list
-    When she clicks [Import] > [From JSON]
-    And she selects a valid .json file
-    Then the playbook is imported
+  Scenario: FOB-IMPORT-EXPORT-1-02 Exported JSON contains correct top-level structure
+    Given Maria has exported "React Frontend Dev" as JSON
+    When the file is parsed
+    Then it contains top-level fields:
+      | field         | type    |
+      | mimir_version | string  |
+      | exported_at   | string  |
+      | playbook      | object  |
+    And mimir_version equals "1.0"
+    And exported_at is a valid ISO8601 timestamp
+    And the playbook object contains:
+      | field   |
+      | status  |
+      | version |
+    And the playbook object does NOT contain:
+      | field  |
+      | id     |
+      | source |
+      | author |
+
+  Scenario: FOB-IMPORT-EXPORT-1-03 Exported JSON contains all playbook entities
+    Given Maria has exported "React Frontend Dev" as JSON
+    When the file is parsed
+    Then playbook.phases contains 1 entry with fields: ref, name, description, order
+    And playbook.agents contains 1 entry with fields: ref, name, description
+    And playbook.skills contains 2 entries each with fields: ref, title, capability_domain, technology_stack, content
+    And playbook.rules contains 3 entries each with fields: ref, title, slug, content, always_apply
+    And playbook.workflows contains 2 entries each with fields: ref, name, description, abbreviation, order, activities
+    And playbook.artifacts contains 2 entries each with fields: ref, name, description, type, is_required, produced_by_ref
+    And the total activity count across all workflows is 6
+
+  Scenario: FOB-IMPORT-EXPORT-1-04 Exported JSON preserves predecessor chain
+    Given the workflow contains:
+      | activity name     | predecessor      |
+      | Define Props      | (none)           |
+      | Create Mockup     | Define Props     |
+      | Write Component   | Create Mockup    |
+    When Maria exports the playbook as JSON
+    Then the activities in the JSON contain:
+      | name            | predecessor_ref         |
+      | Define Props    | null                    |
+      | Create Mockup   | (ref of Define Props)   |
+      | Write Component | (ref of Create Mockup)  |
+    And each predecessor_ref value matches the "ref" field of the referenced activity
+
+  Scenario: FOB-IMPORT-EXPORT-1-05 Exported JSON preserves all entity links on activity
+    Given activity "Implement Component" is linked to agent "Code Reviewer",
+          skill "React Dev", phase "Execution", and rules "pytest-first" and "ruff-format"
+    When Maria exports the playbook as JSON
+    Then the activity entry contains:
+      | field       | value                                      |
+      | agent_ref   | (ref matching "Code Reviewer" in agents)   |
+      | skill_ref   | (ref matching "React Dev" in skills)       |
+      | phase_ref   | (ref matching "Execution" in phases)       |
+      | rules       | [ref of pytest-first, ref of ruff-format]  |
+
+  Scenario: FOB-IMPORT-EXPORT-1-06 Export of released playbook is permitted
+    Given "React Frontend Dev" has status "released" (version 1.2)
+    When Maria exports it as JSON
+    Then the download succeeds
+    And the exported JSON contains status "released" and version "1.2"
+
+  Scenario: FOB-IMPORT-EXPORT-1-07 Export button appears on playbook detail for all statuses
+    Given Maria is viewing a playbook with status "<status>"
+    Then the action menu contains [Export as JSON] with data-testid="export-playbook-json"
+    Examples:
+      | status   |
+      | draft    |
+      | released |
+
+  # ============================================================================
+  # IMPORT
+  # ============================================================================
+
+  Scenario: FOB-IMPORT-EXPORT-1-08 Import valid JSON creates new draft playbook
+    Given Maria is on the playbooks list
+    And no playbook named "Team Playbook" exists
+    When she clicks [Import Playbook] (data-testid="import-playbook-btn")
+    And she selects a valid "team-playbook.json" file (playbook name: "Team Playbook") (data-testid="import-file-input")
+    And she clicks [Import] (data-testid="import-submit-btn")
+    Then a new playbook is created with:
+      | field   | value                      |
+      | status  | (preserved from JSON)      |
+      | version | (preserved from JSON)      |
+      | author  | Maria                      |
+      | source  | imported                   |
+    And she sees success notification "Playbook imported successfully"
+    And she is redirected to the new playbook detail page
+
+  Scenario: FOB-IMPORT-EXPORT-1-09 Import recreates all entities with correct counts
+    Given a valid JSON export file whose playbook name does not exist in the system
+    And the file contains:
+      | entity     | count |
+      | workflows  |     2 |
+      | activities |     6 |
+      | agents     |     1 |
+      | skills     |     2 |
+      | phases     |     1 |
+      | rules      |     3 |
+      | artifacts  |     2 |
+    When Maria imports the file
+    Then the imported playbook contains:
+      | entity     | count |
+      | workflows  |     2 |
+      | activities |     6 |
+      | agents     |     1 |
+      | skills     |     2 |
+      | phases     |     1 |
+      | rules      |     3 |
+      | artifacts  |     2 |
+    And all entity IDs are new database IDs (not the original exported IDs)
+
+  Scenario: FOB-IMPORT-EXPORT-1-10 Import preserves all relationships
+    Given Maria has exported "React Frontend Dev" to "react-frontend-dev.json"
+    When she imports "react-frontend-dev.json" and clicks [Replace] in the conflict dialog
+    Then all activity predecessor chains are intact
+    And all activity-to-agent links are intact
+    And all activity-to-skill links are intact
+    And all activity-to-phase links are intact
+    And all activity-to-rule M2M links are intact
+    And all artifact produced_by activity links are intact
+    And all artifact consumed_by (ArtifactInput) links are intact
+
+  Scenario: FOB-IMPORT-EXPORT-1-11 Round-trip fidelity
+    Given Maria exports "React Frontend Dev" to "export-v1.json"
+    When she imports "export-v1.json" and clicks [Replace] in the conflict dialog
+    Then the imported playbook is named "React Frontend Dev" (original name preserved)
+    When she exports it to "export-v2.json"
+    Then "export-v1.json" and "export-v2.json" are structurally identical
+    Except for the "exported_at" timestamp
+
+  # ============================================================================
+  # CROSS-INSTANCE MIGRATION — the primary use case for this entire feature
+  # ============================================================================
+
+  Scenario: FOB-IMPORT-EXPORT-1-12 Cross-instance migration produces a fully functional playbook
+    # This scenario is the definition of done for the whole feature.
+    # Instance A and Instance B share no database, no user accounts, no IDs.
+    # The JSON file is the only thing that moves between them.
+    Given Maria has playbook "GDD Playbook" on Instance A containing:
+      | entity     | count |
+      | workflows  |     5 |
+      | activities |    23 |
+      | agents     |     2 |
+      | skills     |     3 |
+      | phases     |     4 |
+      | rules      |     4 |
+      | artifacts  |     3 |
+    And activity predecessor chains, agent/skill/phase links, and rule M2M links are all set
+    When she exports "GDD Playbook" as JSON on Instance A
+    And she copies "gdd-playbook.json" to Instance B (a separate Mimir installation)
+    And she imports "gdd-playbook.json" on Instance B
+    Then the playbook exists on Instance B with:
+      | entity     | count |
+      | workflows  |     5 |
+      | activities |    23 |
+      | agents     |     2 |
+      | skills     |     3 |
+      | phases     |     4 |
+      | rules      |     4 |
+      | artifacts  |     3 |
+    And all predecessor chains are intact on Instance B
+    And all agent, skill, phase, and rule links are intact on Instance B
+    And all entity IDs on Instance B are different from the IDs on Instance A
+    And the playbook has no reference to any database state from Instance A
+    And the playbook status and version on Instance B match those from the exported JSON
+    And the playbook source is "imported" on Instance B
+    And the playbook author is Maria's account on Instance B
+
+  # ============================================================================
+  # CONFLICT RESOLUTION
+  # ============================================================================
+
+  Scenario: FOB-IMPORT-EXPORT-1-13 Import conflict dialog appears on name collision
+    Given a playbook named "React Frontend Dev" already exists
+    When Maria imports a JSON file with playbook name "React Frontend Dev"
+    Then she sees a conflict dialog with:
+      | option      | data-testid                  |
+      | Rename      | import-conflict-rename       |
+      | Replace     | import-conflict-replace      |
+      | Add Missing | import-conflict-add-missing  |
+      | Cancel      | import-conflict-cancel       |
+
+  Scenario: FOB-IMPORT-EXPORT-1-14 Import conflict — rename creates with modified name
+    Given a playbook named "React Frontend Dev" already exists
+    When Maria imports a JSON file named "React Frontend Dev"
+    And she clicks [Rename] in the conflict dialog
+    Then a new playbook "React Frontend Dev (imported)" is created with status and version preserved from the JSON
+    And the new playbook has source "imported"
+    And the original playbook is unchanged
+
+  Scenario: FOB-IMPORT-EXPORT-1-15 Import conflict — replace deletes draft and imports
+    Given a DRAFT playbook named "React Frontend Dev" (id=1) already exists
+    When Maria imports a JSON also named "React Frontend Dev"
+    And she clicks [Replace] in the conflict dialog
+    Then she sees confirmation: "This will permanently delete the existing playbook. Continue?"
+    When she confirms
+    Then the original playbook (id=1) and all its content are deleted
+    And the new playbook is created from the imported JSON with status and version preserved from the JSON, and source "imported"
     And she sees success notification
+    And the deletion and creation are a single atomic operation: if the import fails, the original playbook is preserved
 
-  Scenario: FOB-IMPORT-04 Import validation errors
-    Given Maria imports an invalid JSON
-    Then she sees validation errors
-    And she can fix errors or cancel import
+  Scenario: FOB-IMPORT-EXPORT-1-16 Import conflict — replace blocked for released playbook
+    Given a RELEASED playbook named "React Frontend Dev" already exists
+    When Maria imports a JSON also named "React Frontend Dev"
+    And she clicks [Replace] in the conflict dialog
+    Then she sees error "Cannot replace a released playbook. Choose Rename or Cancel."
+    And the released playbook is unchanged
 
-  Scenario: FOB-IMPORT-05 Import with conflict resolution
-    Given Maria imports a playbook with same name
-    Then she sees conflict dialog
-    And she can: Rename, Replace, or Cancel
+  Scenario: FOB-IMPORT-EXPORT-1-17 Import conflict — cancel leaves everything unchanged
+    Given a playbook named "React Frontend Dev" already exists
+    When Maria imports a JSON also named "React Frontend Dev"
+    And she clicks [Cancel] in the conflict dialog
+    Then no new playbook is created
+    And the original playbook is unchanged
+    And she is returned to the import dialog
 
-  Scenario: FOB-IMPORT-06 Bulk export multiple playbooks
-    Given Maria selects 3 playbooks
-    When she clicks [Bulk Export]
-    Then all 3 playbooks are exported as single .zip file
+  Scenario: FOB-IMPORT-EXPORT-1-18 Import conflict — add missing adds only absent entities
+    Given a playbook named "React Frontend Dev" already exists containing 2 workflows and 6 activities
+    When Maria imports a JSON also named "React Frontend Dev" containing 3 workflows and 9 activities
+    And she clicks [Add Missing] in the conflict dialog
+    Then the 2 existing workflows are unchanged
+    And the 1 new workflow from the JSON is added to the existing playbook
+    And the 6 existing activities are unchanged
+    And the 3 new activities from the JSON are added
+    And no existing entity is deleted or overwritten
+    And she sees success notification "Playbook updated with missing entities"
+    And if the operation fails, no new entities are added and the existing playbook is unchanged
+
+  # ============================================================================
+  # VALIDATION AND ERRORS
+  # ============================================================================
+
+  Scenario: FOB-IMPORT-EXPORT-1-19 Import invalid JSON syntax
+    Given Maria selects a file containing malformed JSON (e.g. missing closing brace)
+    When she submits the import
+    Then she sees error "Invalid file: could not be parsed as JSON"
+    And no playbook is created
+
+  Scenario: FOB-IMPORT-EXPORT-1-20 Import JSON missing required playbook.name
+    Given Maria selects a JSON file where playbook.name is absent
+    When she submits the import
+    Then she sees validation error "Missing required field: playbook.name"
+    And no playbook is created
+
+  Scenario: FOB-IMPORT-EXPORT-1-21 Import JSON with broken predecessor reference
+    Given Maria selects a JSON where activity "Create Mockup" has predecessor_ref "activity-99"
+    But no activity with ref "activity-99" exists in the file
+    When she submits the import
+    Then she sees validation error:
+      "Activity 'Create Mockup' references unknown predecessor 'activity-99'"
+    And no playbook is created
+    And no partial entities remain in the database
+
+  Scenario: FOB-IMPORT-EXPORT-1-22 Import non-JSON file type
+    Given Maria selects a file "document.pdf"
+    When she submits the import
+    Then she sees error "Unsupported file type. Please upload a .json file"
+    And no playbook is created
+
+  Scenario: FOB-IMPORT-EXPORT-1-23 Import JSON with unknown mimir_version
+    Given Maria selects a JSON file with mimir_version "99.0"
+    When she submits the import
+    Then she sees error "Unsupported export version: 99.0. This instance supports version 1.0."
+    And no playbook is created

--- a/docs/features/act-3-workflows/workflows-export-import.feature
+++ b/docs/features/act-3-workflows/workflows-export-import.feature
@@ -197,3 +197,141 @@ Feature: FOB-WORKFLOWS-EXPORT_IMPORT-1 MCP Workflow Synchronization
     And AI suggests: "Add error handling guidance to Activity 8"
     And AI suggests: "Split Activity 12 into two smaller activities"
     And Maria can accept suggestions and import changes via MCP
+
+  # ============================================================================
+  # MCP FULL PLAYBOOK EXPORT / IMPORT
+  # Covers portability between Mimir instances — complements UI-level act-10.
+  # JSON schema is defined in act-10-import-export/import-export.feature.
+  # ============================================================================
+
+  # PRIMARY USE CASE for MCP playbook export/import:
+  # Two separate Mimir instances, no shared DB, no shared filesystem.
+  # Cascade exports on Instance A → Maria copies the file → Cascade imports on Instance B.
+  # The JSON file is the only transfer mechanism.
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-19 Cross-instance migration via MCP
+    # Golden path: export on one instance, import on another.
+    Given Cascade is connected to Mimir MCP on Instance A
+    And playbook (id=4) "GDD Playbook" exists on Instance A
+    When Cascade calls "export_playbook" with playbook_id=4 and output_path="./exports/gdd-playbook.json"
+    And Maria copies "gdd-playbook.json" to Instance B
+    And Cascade calls "import_playbook" with input_path="./exports/gdd-playbook.json" on Instance B
+    Then the playbook exists on Instance B with all workflows, activities, and entity links intact
+    And all entity IDs on Instance B differ from those on Instance A
+    And the playbook has no dependency on Instance A's database state
+    And the playbook status and version on Instance B match those from the exported JSON
+    And the playbook source is "imported" on Instance B
+    And the playbook is owned by the current MCP user on Instance B
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-20 Export full playbook to JSON file via MCP
+    Given playbook (id=4) has 5 workflows, 23 activities, 2 agents, 3 skills, 4 rules, 3 phases, 4 artifacts
+    When Cascade calls MCP tool "export_playbook" with:
+      | playbook_id | 4                             |
+      | output_path | ./exports/gdd-playbook.json   |
+    Then MCP writes a valid JSON file to "./exports/gdd-playbook.json"
+    And MCP returns success with:
+      | field      | value                        |
+      | path       | ./exports/gdd-playbook.json  |
+      | workflows  | 5                            |
+      | activities | 23                           |
+      | agents     | 2                            |
+      | skills     | 3                            |
+      | rules      | 4                            |
+      | phases     | 3                            |
+      | artifacts  | 4                            |
+    And the JSON conforms to the schema defined in act-10
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-21 Import full playbook from JSON file via MCP
+    Given a valid "gdd-playbook.json" exists at "./exports/gdd-playbook.json"
+    And no playbook with the name from that file exists on this instance
+    When Cascade calls MCP tool "import_playbook" with:
+      | input_path | ./exports/gdd-playbook.json |
+    Then MCP creates a new playbook from the JSON
+    And MCP returns success with:
+      | field       | value                   |
+      | playbook_id | (new integer ID)        |
+      | name        | (name from JSON)        |
+      | status      | (preserved from JSON)   |
+      | version     | (preserved from JSON)   |
+      | source      | imported                |
+    And the new playbook contains all entities from the source file
+    And the playbook author is the current MCP user
+
+  # ============================================================================
+  # NAME COLLISION STRATEGIES
+  # import_playbook accepts an optional conflict_strategy parameter.
+  # Matching is always by name: workflow by name, activity by (workflow_name, activity_name),
+  # agent/skill/phase/rule/artifact each by their own name or slug.
+  # Default (no parameter): raise an error if a playbook with the same name exists.
+  # conflict_strategy=replace: delete existing playbook and all its content, import fresh.
+  # conflict_strategy=add_missing: add absent entities to the existing playbook, skip existing.
+  #   If no playbook with that name exists, add_missing behaves identically to the default
+  #   happy path — the playbook is created fresh with no conflict to resolve.
+  # Note: add_missing is available in both MCP (conflict_strategy parameter) and UI
+  #   ([Add Missing] button in the conflict dialog) — behaviour is identical.
+  # ============================================================================
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-22 Import name collision with no strategy raises error
+    Given Instance B already has a playbook named "GDD Playbook"
+    When Cascade calls "import_playbook" with:
+      | input_path | ./exports/gdd-playbook.json |
+    Then MCP returns error:
+      "ConflictError: Playbook 'GDD Playbook' already exists.
+       Use conflict_strategy='replace' to overwrite or 'add_missing' to add only new entities."
+    And the existing playbook is unchanged
+    And no new playbook is created
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-23 conflict_strategy=replace drops existing and imports fresh
+    Given Instance B already has playbook "GDD Playbook" with 10 activities
+    When Cascade calls "import_playbook" with:
+      | input_path        | ./exports/gdd-playbook.json |
+      | conflict_strategy | replace                     |
+    Then the existing "GDD Playbook" and all its content are permanently deleted
+    And a new playbook "GDD Playbook" is created from the JSON
+    And the new playbook has status and version preserved from the JSON, and source "imported"
+    And the new playbook contains exactly the entities from the JSON file
+    And the deletion and creation are a single atomic operation: if the import fails, the original playbook is preserved
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-24 conflict_strategy=add_missing adds only absent entities
+    Given Instance B already has playbook "GDD Playbook" containing:
+      | entity type | name               | present |
+      | workflow    | VIS — Vision       | yes     |
+      | workflow    | DYN — Dynamics     | no      |
+      | activity    | Define aesthetic   | yes     |
+      | activity    | Write elevator pitch | no    |
+    When Cascade calls "import_playbook" with:
+      | input_path        | ./exports/gdd-playbook.json |
+      | conflict_strategy | add_missing                 |
+    Then workflow "VIS — Vision" is not modified (already present by name)
+    And activity "Define aesthetic" is not modified (already present by name)
+    And workflow "DYN — Dynamics" is created (was absent)
+    And activity "Write elevator pitch" is created (was absent)
+    And no existing entity is deleted or overwritten
+    And if the operation fails, no new entities are added and the existing playbook is unchanged
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-25 MCP round-trip preserves full structure
+    Given Cascade exports playbook (id=4) to "./exports/export-v1.json"
+    When Cascade imports "./exports/export-v1.json" with conflict_strategy="replace"
+    And Cascade exports the newly imported playbook to "./exports/export-v2.json"
+    Then "export-v1.json" and "export-v2.json" are structurally identical
+    Except for the "exported_at" timestamp
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-26 Export non-existent playbook raises error
+    When Cascade calls "export_playbook" with:
+      | playbook_id | 999                      |
+      | output_path | ./exports/missing.json   |
+    Then MCP returns error "ValueError: Playbook 999 not found"
+    And no file is written
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-27 Import from non-existent file raises error
+    When Cascade calls "import_playbook" with:
+      | input_path | ./exports/nonexistent.json |
+    Then MCP returns error "ValueError: File not found: ./exports/nonexistent.json"
+
+  Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-28 Import JSON with broken predecessor reference raises error
+    Given a JSON file where activity "Create Mockup" has predecessor_ref "activity-99"
+    But no activity with ref "activity-99" exists in the file
+    When Cascade calls "import_playbook" with that file
+    Then MCP returns error "ValueError: Activity 'Create Mockup' references unknown predecessor 'activity-99'"
+    And no playbook is created
+    And no partial entities remain in the database


### PR DESCRIPTION
## Summary

- **Complete act-10 spec** (`import-export.feature`) — 23 scenarios covering UI-level JSON export/import, replacing the empty stub that existed before
- **Extend act-3 MCP section** (`workflows-export-import.feature`) — adds scenarios 19–28 for MCP-level `export_playbook` / `import_playbook` tools
- Both specs align on the same JSON schema, conflict strategies, atomicity guarantees, and status/version preservation semantics

## Primary use case

Cross-instance migration: Maria exports a playbook from her dev instance as a self-contained JSON file and imports it on a team instance that shares **no database, no IDs, and no user accounts**. The JSON file is the only transfer mechanism.

## Key design decisions in the spec

| Decision | Detail |
|---|---|
| JSON schema | Stable `ref` string identifiers (not DB PKs) for all cross-references; excluded fields: `id`, `source`, `author`, `created_at`, `updated_at` |
| Artifact ownership | `produced_by_ref` on artifact is the sole canonical field — mirrors DB FK direction; no `artifacts_produced` list on activity |
| Status/version preservation | Imported released v1.2 playbook arrives as released v1.2 on the target instance |
| `source: imported` | Set on all imported playbooks; model change (adding `'imported'` to `SOURCE_CHOICES`) is **deferred to the implementation PR** |
| Atomicity (3 modes) | Default failure → nothing created; `replace` → delete+create is one atomic unit (original preserved on failure); `add_missing` → all new additions or none (existing playbook always unchanged on failure) |
| Conflict resolution | UI: 4 options with `data-testid`s (Rename / Replace / Add Missing / Cancel); MCP: `conflict_strategy` param (`replace` / `add_missing` / default ConflictError) |
| MCP/UI parity | `add_missing` behaviour is identical via both entry points; matching keys: workflow by name, activity by `(workflow_name, activity_name)`, all others by name or slug |

## Scope

### `act-10-import-export/import-export.feature` (23 scenarios, 01–23)
- JSON schema definition comment block
- Export: download trigger, top-level structure, all entities, predecessor chain, entity links, released playbook, button visibility
- Import: happy path with entity counts, relationship preservation, round-trip fidelity, cross-instance migration
- Conflict dialog: Rename, Replace (with atomicity), Replace blocked for released, Add Missing (with atomicity), Cancel
- Validation/errors: invalid JSON, missing `playbook.name`, broken predecessor ref, non-JSON file type, unknown `mimir_version`

### `act-3-workflows/workflows-export-import.feature` (scenarios 19–28)
- Golden path cross-instance migration
- `export_playbook` MCP tool with response table
- `import_playbook` MCP tool (happy path, no-collision precondition added)
- Name collision strategies: default error, `replace`, `add_missing`
- Round-trip structural identity
- Error scenarios: non-existent playbook, non-existent file, broken predecessor ref

## Implementation prerequisite

Before implementing, add `('imported', 'Imported')` to `SOURCE_CHOICES` in `methodology/models/playbook.py` and run `makemigrations`.

## Test plan

- [ ] Read `act-10-import-export/import-export.feature` end-to-end — verify 23 scenarios, no number gaps, Background consistent with all scenarios
- [ ] Read MCP scenarios 19–28 in `workflows-export-import.feature` — verify no number gaps, cross-spec consistency with act-10 schema
- [ ] Confirm `source` excluded from JSON export schema comment but asserted as `imported` in import assertions
- [ ] Confirm status/version appear in schema, in Scenario 02 "contains" table, and in all import assertions (08, 14, 15, 21, 23)
- [ ] Confirm three atomicity modes are each covered by at least one explicit assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)