### PR TITLE
fix(ui): UAT bugs #120 alert colors + #121 navbar search styling

### DIFF
--- a/mimir/settings/base.py
+++ b/mimir/settings/base.py
@@ -9,6 +9,8 @@ import logging
 import os
 from pathlib import Path
 
+from django.contrib.messages import constants as message_constants
+
 logger = logging.getLogger(__name__)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -190,3 +192,6 @@ REST_FRAMEWORK = {
     ],
     'EXCEPTION_HANDLER': 'methodology.api.exceptions.custom_exception_handler',
 }
+
+# Django messages → Bootstrap alert classes (alert-danger, not alert-error).
+MESSAGE_TAGS = {message_constants.ERROR: 'danger'}

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,21 @@
         [data-testid="main-navbar"] .navbar-nav.me-auto .nav-link {
             font-size: 0.875rem;
         }
+        /* Dark-navbar search input */
+        #global-search-input {
+            background-color: rgba(255, 255, 255, 0.1);
+            border-color: rgba(255, 255, 255, 0.25);
+            color: #fff;
+        }
+        #global-search-input::placeholder {
+            color: rgba(255, 255, 255, 0.55);
+        }
+        #global-search-input:focus {
+            background-color: rgba(255, 255, 255, 0.15);
+            border-color: rgba(255, 255, 255, 0.45);
+            color: #fff;
+            box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.1);
+        }
         /* Feedback tab: vertical strip on the right (writing-mode; no rotate — keeps pin math stable). */
         .feedback-edge-tab {
             position: fixed;


### PR DESCRIPTION
## Summary
- **#121**: Map Django `messages.ERROR` → Bootstrap `alert-danger` via `MESSAGE_TAGS`
- **#120**: Style global search input for dark navbar (semi-transparent bg, light text/placeholder)

## Test plan
- [x] `pytest tests/ --ignore=tests/e2e` — 1042 passed, 5 skipped
- [x] Closed rejected issues #123, #122-A, #105, #108 with triage explanations