### PR TITLE
fix(auth): redirect logged-in users from login/register to profile (#125)

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -32,6 +32,21 @@ _PROFILE_PLAYBOOKS_LIMIT = 50
 _PROFILE_PIPS_LIMIT = 50
 
 
+def _redirect_if_authenticated(request):
+    """Send logged-in users away from guest-only auth pages (login/register).
+
+    :param request: Django request object
+    :return: Redirect to profile when authenticated, else ``None``.
+    """
+    if request.user.is_authenticated:
+        logger.info(
+            "Authenticated user %s redirected from guest auth page to profile",
+            request.user.username,
+        )
+        return redirect(reverse("profile"))
+    return None
+
+
 def _profile_playbooks_for(user):
     """Return playbooks authored by user (newest first), capped for the profile page."""
     return list(
@@ -172,6 +187,10 @@ def login_view(request):
     :return: Rendered login template or redirect to dashboard
     """
     logger.info(f"Login page accessed via {request.method}")
+
+    redirect_response = _redirect_if_authenticated(request)
+    if redirect_response is not None:
+        return redirect_response
     
     # GET request - display form
     if request.method == 'GET':
@@ -657,6 +676,10 @@ def register(request):
     no auto-login — redirect to login with an info message.
     """
     logger.info("Registration page accessed via %s", request.method)
+
+    redirect_response = _redirect_if_authenticated(request)
+    if redirect_response is not None:
+        return redirect_response
 
     empty_ctx = {
         "errors": {},

--- a/docs/features/act-0-auth/authentication.feature
+++ b/docs/features/act-0-auth/authentication.feature
@@ -38,6 +38,26 @@ Feature: FOB-AUTH-LOGIN-1 Authentication and Login
     When she ticks [Remember me for 30 days] and signs in
     Then her session cookie persists for 30 days
 
+  # ── Guest-only guards (logged-in users) ───────────────────────────────────
+
+  Scenario: FOB-AUTH-GUARD-01 Logged-in user cannot access login page
+    Given Maria is logged in
+    When she navigates to /auth/user/login/
+    Then she is redirected to FOB-PROFILE-VIEW-1 at /auth/user/profile/
+    And she does NOT see the login form
+
+  Scenario: FOB-AUTH-GUARD-02 Logged-in user cannot access registration page
+    Given Maria is logged in
+    When she navigates to /auth/user/register/
+    Then she is redirected to FOB-PROFILE-VIEW-1 at /auth/user/profile/
+    And she does NOT see the registration form
+
+  Scenario: FOB-AUTH-GUARD-03 Logged-in POST to login is redirected without re-auth
+    Given Maria is logged in
+    When she POSTs credentials to /auth/user/login/
+    Then she is redirected to FOB-PROFILE-VIEW-1 at /auth/user/profile/
+    And she remains authenticated as Maria
+
   # ── Registration ──────────────────────────────────────────────────────────
 
   Scenario: FOB-LOCAL-USER-CREATE-01 First-time user registration

--- a/tests/integration/test_auth_guest_guards.py
+++ b/tests/integration/test_auth_guest_guards.py
@@ -1,0 +1,86 @@
+"""Integration tests for guest-only auth page guards.
+
+Covers FOB-AUTH-GUARD-* scenarios in docs/features/act-0-auth/authentication.feature
+and UAT-01-05 in tests/uat/e2e-uat-flow.feature.
+
+NO MOCKING per .windsurf/rules/do-not-mock-in-integration-tests.md
+"""
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+from accounts.models import mark_email_verified
+
+
+@pytest.mark.django_db
+class TestAuthGuestGuards:
+    """Logged-in users must not see login or registration forms."""
+
+    @pytest.fixture
+    def authenticated_client(self):
+        client = Client()
+        user = User.objects.create_user(
+            username="maria",
+            email="maria@example.com",
+            password="ValidPass123",
+        )
+        mark_email_verified(user)
+        client.force_login(user)
+        return client, user
+
+    def test_logged_in_get_login_redirects_to_profile(self, authenticated_client):
+        """FOB-AUTH-GUARD-01: login page redirects authenticated users to profile."""
+        client, _user = authenticated_client
+        response = client.get(reverse("login"), follow=False)
+
+        assert response.status_code == 302
+        assert response.url == reverse("profile")
+
+        profile_response = client.get(reverse("profile"))
+        content = profile_response.content.decode("utf-8")
+        assert 'data-testid="profile-page"' in content
+        assert 'data-testid="login-form"' not in content
+
+    def test_logged_in_get_register_redirects_to_profile(self, authenticated_client):
+        """FOB-AUTH-GUARD-02: registration page redirects authenticated users to profile."""
+        client, _user = authenticated_client
+        response = client.get(reverse("register"), follow=False)
+
+        assert response.status_code == 302
+        assert response.url == reverse("profile")
+
+        profile_response = client.get(reverse("profile"))
+        content = profile_response.content.decode("utf-8")
+        assert 'data-testid="profile-page"' in content
+        assert 'data-testid="register-form"' not in content
+
+    def test_logged_in_post_login_redirects_to_profile_without_reauth(
+        self, authenticated_client
+    ):
+        """FOB-AUTH-GUARD-03: POST login while authenticated redirects to profile."""
+        client, user = authenticated_client
+        response = client.post(
+            reverse("login"),
+            {"username": "other", "password": "WrongPass123"},
+            follow=False,
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("profile")
+
+        dashboard = client.get("/dashboard/")
+        assert dashboard.wsgi_request.user.is_authenticated
+        assert dashboard.wsgi_request.user.username == user.username
+
+    def test_anonymous_user_can_still_access_login_and_register(self):
+        """Guest pages remain available to anonymous sessions."""
+        client = Client()
+
+        login_response = client.get(reverse("login"))
+        assert login_response.status_code == 200
+        assert 'data-testid="login-form"' in login_response.content.decode("utf-8")
+
+        register_response = client.get(reverse("register"))
+        assert register_response.status_code == 200
+        assert 'data-testid="register-form"' in register_response.content.decode("utf-8")

--- a/tests/uat/e2e-uat-flow.feature
+++ b/tests/uat/e2e-uat-flow.feature
@@ -134,6 +134,22 @@ Feature: Mimir E2E UAT — browser-only flow (registration → GUI CRUDL → rel
     # STEP D — regenerate wrong-password branch
     # DO: fill `[data-testid=\"profile-token-regenerate-password\"]` literal `incorrect-password-uat`; submit `[data-testid=\"profile-token-regenerate-submit\"]`
     # SEE: flash `[data-testid=\"alert-message\"]` EXACT `Incorrect password. Your API token was not changed.`
+
+  @manual @uat @act-0 @profile
+  Scenario: UAT-01-05 Logged-in user cannot access login or register (guest-only guard)
+    # Pre: `<UAT_USERNAME>` session still active from UAT-01-04 (do NOT logout)
+    # STEP A — Login page guard
+    # DO: GET `/auth/user/login/` while authenticated
+    # SEE: redirect URL `/auth/user/profile/`; `[data-testid=\"profile-page\"]` visible; NO `[data-testid=\"login-form\"]`
+    # IF DIFFER: UAT-01-05 STEP A
+    # STEP B — Register page guard
+    # DO: GET `/auth/user/register/` while authenticated
+    # SEE: redirect URL `/auth/user/profile/`; `[data-testid=\"profile-page\"]` visible; NO `[data-testid=\"register-form\"]`
+    # IF DIFFER: UAT-01-05 STEP B
+    # STEP C — POST login guard (no re-auth)
+    # DO: POST `/auth/user/login/` with any credentials while still authenticated
+    # SEE: redirect `/auth/user/profile/`; navbar `[data-testid=\"user-display\"]` still shows `<UAT_USERNAME>`
+    # IF DIFFER: UAT-01-05 STEP C
 #############################################################################
 # Journey 2 — MCP token wiring + smoke negatives → see mcp-uat-flow.feature
 #############################################################################


### PR DESCRIPTION
## Summary
- Redirect authenticated users from `/auth/user/login/` and `/auth/user/register/` to `/auth/user/profile/`
- POST to login while logged in also redirects (no re-auth attempt)
- Extended `docs/features/act-0-auth/authentication.feature` with FOB-AUTH-GUARD-01..03
- Added UAT-01-05 to `tests/uat/e2e-uat-flow.feature`
- New integration tests: `tests/integration/test_auth_guest_guards.py`

Fixes #125

## Test plan
- [x] `pytest tests/integration/test_auth_guest_guards.py` — 4 passed
- [x] `pytest tests/integration/test_auth_login.py tests/integration/test_auth_registration.py` — 21 passed