### PR TITLE
fix(auth): send password reset via EmailService for SES compatibility

### DIFF
--- a/accounts/services/email_service.py
+++ b/accounts/services/email_service.py
@@ -90,17 +90,15 @@ The Mimir Team
         EmailService.send_text_email(subject, body, [user.email])
 
     @staticmethod
-    def send_password_reset_email(user: AbstractBaseUser, reset_token: str) -> None:
-        """Send password reset email with token link.
+    def send_password_reset_email(user: AbstractBaseUser, reset_url: str) -> None:
+        """Send password reset email with confirm link.
 
         :param user: Django user.
-        :param reset_token: Opaque reset token from Django's auth framework.
+        :param reset_url: Absolute URL to ``password_reset_confirm`` view.
         :raises Exception: If delivery fails.
         """
-        base_url = EmailService.get_site_base_url()
-        reset_url = f"{base_url}/reset-password?token={reset_token}"
         name = user.first_name or user.username
-        subject = "Password Reset Request"
+        subject = "Password Reset - Mimir"
         body = f"""Hello {name},
 
 You requested a password reset for your Mimir account.
@@ -108,9 +106,7 @@ You requested a password reset for your Mimir account.
 Reset your password at:
 {reset_url}
 
-This link will expire in 24 hours.
-
-If you didn't request this, please ignore this email.
+If you did not request this, please ignore this email.
 
 Best regards,
 The Mimir Team

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -858,22 +858,10 @@ def password_reset_request(request):
             'timestamp': str(__import__('datetime').datetime.now())
         }
         
-        # Send email (console backend - will print to console)
-        from django.core.mail import send_mail
-        from django.urls import reverse
-        
         reset_url = request.build_absolute_uri(
-            reverse('password_reset_confirm', kwargs={'uidb64': uid, 'token': token})
+            reverse("password_reset_confirm", kwargs={"uidb64": uid, "token": token})
         )
-        
-        send_mail(
-            subject='Password Reset - Mimir',
-            message=f'Click the link to reset your password:\n\n{reset_url}\n\nIf you did not request this, please ignore this email.',
-            from_email='noreply@mimir.local',
-            recipient_list=[email],
-            fail_silently=False,
-        )
-        
+        EmailService.send_password_reset_email(user, reset_url)
         logger.info(f"Password reset email sent to {email}")
     except User.DoesNotExist:
         # Security: Don't reveal if email exists

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,4 +20,5 @@ markers =
     integration: Integration tests
     e2e: End-to-end tests (requires --browser chromium flag)
     slow: Slow running tests
+    live_ses: Opt-in test that sends one real SES email (requires env vars)
 asyncio_default_fixture_loop_scope = function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,17 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
+@pytest.fixture(autouse=True)
+def block_real_email_sends(request, settings):
+    """Force locmem mail backend for every test except @pytest.mark.live_ses.
+
+    Prevents accidental SES sends when pytest runs with prod-like env vars.
+    """
+    if request.node.get_closest_marker("live_ses"):
+        return
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+
 @pytest.fixture
 def create_test_phases(db):
     """

--- a/tests/integration/test_auth_password_reset.py
+++ b/tests/integration/test_auth_password_reset.py
@@ -3,8 +3,10 @@
 Tests from docs/features/act-0-auth/authentication.feature
 
 NO MOCKING per .windsurf/rules/do-not-mock-in-integration-tests.md
+Uses locmem email backend only — never sends via SES.
 """
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
@@ -17,12 +19,12 @@ class TestPasswordReset:
     
     def test_password_reset_request_sends_email(self):
         """
-        Test password reset request sends email to console.
+        Test password reset request captures email in locmem outbox.
         
         Scenario: AUTH-04 Password reset
         Given: Maria has an account
         When: she requests password reset
-        Then: email is sent (to console per plan)
+        Then: email is captured in locmem outbox (no SES)
         """
         # Arrange
         client = Client()
@@ -43,9 +45,11 @@ class TestPasswordReset:
         content = response.content.decode('utf-8')
         assert 'sent' in content.lower() or 'email' in content.lower()
         
-        # Assert - Email should be sent (console backend)
+        # Assert - Email captured in locmem (never SES)
+        assert "django_ses" not in settings.EMAIL_BACKEND
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == ['maria@example.com']
+        assert mail.outbox[0].from_email == settings.DEFAULT_FROM_EMAIL
         assert 'Password Reset' in mail.outbox[0].subject
         assert 'password-reset-confirm' in mail.outbox[0].body
     

--- a/tests/integration/test_email_service.py
+++ b/tests/integration/test_email_service.py
@@ -73,10 +73,18 @@ def test_send_welcome_email_uses_email_backend(mail_user):
 @pytest.mark.django_db
 @override_settings(EMAIL_BACKEND=_LOCMEM)
 def test_send_password_reset_email_uses_email_backend(mail_user):
-    EmailService.send_password_reset_email(mail_user, "reset-token")
+    reset_url = "http://localhost:8000/auth/user/password-reset-confirm/abc/token/"
+    EmailService.send_password_reset_email(mail_user, reset_url)
     assert len(mail.outbox) == 1
     assert "Password Reset" in mail.outbox[0].subject
-    assert "reset-token" in mail.outbox[0].body
+    assert reset_url in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+@override_settings(EMAIL_BACKEND=_LOCMEM, DEFAULT_FROM_EMAIL="noreply@test.local")
+def test_send_password_reset_email_uses_default_from_email(mail_user):
+    EmailService.send_password_reset_email(mail_user, "http://localhost/reset/")
+    assert mail.outbox[0].from_email == "noreply@test.local"
 
 
 @pytest.mark.django_db

--- a/tests/integration/test_pip_email.py
+++ b/tests/integration/test_pip_email.py
@@ -292,6 +292,7 @@ _skip_live = pytest.mark.skipif(
 
 
 @_skip_live
+@pytest.mark.live_ses
 @pytest.mark.django_db(transaction=True)
 def test_live_ses_pip_decision_email_sends(
     submitter, admin_user, playbook_with_activity, settings


### PR DESCRIPTION
## Summary
- Route password reset through `EmailService.send_password_reset_email()` so production uses `DEFAULT_FROM_EMAIL` (`noreply@featurefactory.io`) instead of hardcoded `noreply@mimir.local`, which caused SES `AccessDenied` 500s on `/auth/user/password-reset/`.
- Align `EmailService` with the real confirm URL (`/auth/user/password-reset-confirm/...`) instead of the stale `/reset-password?token=` path.
- Harden email tests: locmem autouse guard (skip for `@pytest.mark.live_ses`), `from_email` assertion on password reset, and registered `live_ses` marker.

## Test plan
- [x] `pytest tests/integration/test_auth_password_reset.py tests/integration/test_email_service.py -q` (15 passed)
- [ ] After deploy to idle: request password reset on prod and confirm email arrives from `noreply@featurefactory.io`