### PR TITLE
fix(pips): render change content as markdown in preview and detail

### DIFF
--- a/methodology/services/pip_service.py
+++ b/methodology/services/pip_service.py
@@ -636,11 +636,13 @@ class PIPService:
             label = (
                 ch.name or ch.target_name_snapshot or str(ch.target_id or "")
             ).strip()
+            content = ch.content or ""
             rows.append(
                 {
                     "section": f"{ch.entity_type}:{label or 'target'}",
                     "change_type": entity_bucket.get(ch.change_type, ch.change_type),
-                    "snippet": (ch.content or "")[:400],
+                    "snippet": content[:400],
+                    "content": content,
                 }
             )
         return rows

--- a/templates/includes/markdown_content_assets.html
+++ b/templates/includes/markdown_content_assets.html
@@ -1,0 +1,64 @@
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script>
+    mermaid.initialize({
+        startOnLoad: true,
+        theme: 'default',
+        securityLevel: 'loose'
+    });
+</script>
+<style>
+    .markdown-content {
+        line-height: 1.6;
+    }
+    .markdown-content h1, .markdown-content h2, .markdown-content h3,
+    .markdown-content h4, .markdown-content h5, .markdown-content h6 {
+        margin-top: 1.5rem;
+        margin-bottom: 0.75rem;
+    }
+    .markdown-content h1 { font-size: 1.75rem; }
+    .markdown-content h2 { font-size: 1.5rem; }
+    .markdown-content h3 { font-size: 1.25rem; }
+    .markdown-content pre {
+        background-color: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 0.25rem;
+        padding: 1rem;
+        overflow-x: auto;
+    }
+    .markdown-content code {
+        background-color: #f8f9fa;
+        padding: 0.2rem 0.4rem;
+        border-radius: 0.25rem;
+        font-size: 0.875em;
+    }
+    .markdown-content pre code {
+        background-color: transparent;
+        padding: 0;
+    }
+    .markdown-content img {
+        max-width: 100%;
+        height: auto;
+    }
+    .markdown-content table {
+        width: 100%;
+        margin-bottom: 1rem;
+        border-collapse: collapse;
+    }
+    .markdown-content table th,
+    .markdown-content table td {
+        padding: 0.75rem;
+        border: 1px solid #dee2e6;
+    }
+    .markdown-content table thead th {
+        background-color: #f8f9fa;
+        font-weight: 600;
+    }
+    .mermaid {
+        text-align: center;
+        margin: 1rem 0;
+    }
+    .pip-preview-markdown {
+        max-height: 28rem;
+        overflow-y: auto;
+    }
+</style>

--- a/templates/pips/detail.html
+++ b/templates/pips/detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load markdown_filters %}
 {% block title %}PIP-{{ pip.pk }} — Mimir{% endblock %}
 {% block content %}
 <div class="container mt-4 pb-5" data-testid="pip-detail-page">
@@ -127,7 +128,13 @@
                             {% if ch.target_entity_ref %}<span class="me-2">tgt: <code>{{ ch.target_entity_ref }}</code></span>{% endif %}
                         </p>
                         {% endif %}
-                        <pre class="bg-light border rounded p-3 small mb-2" style="white-space: pre-wrap;" data-testid="pip-change-content-{{ ch.order }}">{{ ch.content|default:'(empty)' }}</pre>
+                        {% if ch.content %}
+                        <div class="markdown-content border rounded p-3 mb-2" data-testid="pip-change-content-{{ ch.order }}">
+                            {{ ch.content|markdown }}
+                        </div>
+                        {% else %}
+                        <p class="text-muted small mb-2" data-testid="pip-change-content-{{ ch.order }}">(empty)</p>
+                        {% endif %}
                         {% if ch.galdr_reasoning %}
                         <div class="small mt-2" data-testid="galdr-reason-{{ ch.order }}">
                             <span class="text-secondary">Galdr rationale:</span> {{ ch.galdr_reasoning }}
@@ -171,4 +178,5 @@
     status: "{{ pip.status|escapejs }}",
     can_submit: {{ can_submit|yesno:"true,false" }},
 });</script>
+{% include "includes/markdown_content_assets.html" %}
 {% endblock %}

--- a/templates/pips/preview.html
+++ b/templates/pips/preview.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load markdown_filters %}
 {% block title %}PIP-{{ pip.pk }} preview{% endblock %}
 {% block content %}
 <div class="container mt-4" data-testid="pip-preview-page">
@@ -9,19 +10,23 @@
         </div>
         <a href="{% url 'pip_edit' pip.pk %}" class="btn btn-outline-secondary flex-shrink-0" data-testid="pip-preview-back"><i class="fas fa-arrow-left me-1"></i>Back to editor</a>
     </div>
-    <table class="table table-sm">
-        <thead><tr><th>Section</th><th>Change</th><th>Snippet</th></tr></thead>
-        <tbody>
-        {% for row in rows %}
-        <tr>
-            <td>{{ row.section }}</td>
-            <td>{{ row.change_type }}</td>
-            <td class="small"><pre class="mb-0">{{ row.snippet }}</pre></td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="3" class="text-muted">No changes yet.</td></tr>
-        {% endfor %}
-        </tbody>
-    </table>
+    {% for row in rows %}
+    <div class="card mb-3" data-testid="pip-preview-row">
+        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2 py-2">
+            <span class="fw-semibold">{{ row.section }}</span>
+            <span class="badge bg-secondary">{{ row.change_type }}</span>
+        </div>
+        {% if row.content %}
+        <div class="card-body markdown-content pip-preview-markdown" data-testid="pip-preview-content">
+            {{ row.content|markdown }}
+        </div>
+        {% elif row.snippet %}
+        <div class="card-body small text-muted">{{ row.snippet }}</div>
+        {% endif %}
+    </div>
+    {% empty %}
+    <div class="text-muted border rounded p-3">No changes yet.</div>
+    {% endfor %}
 </div>
+{% include "includes/markdown_content_assets.html" %}
 {% endblock %}

--- a/tests/integration/test_pip_create_views.py
+++ b/tests/integration/test_pip_create_views.py
@@ -134,3 +134,52 @@ def test_pip_add_change_accepts_parent_workflow_ref_via_gui(maria, released_pb):
     assert act_change.parent_workflow_ref == "#wf1"
     assert act_change.parent_workflow_id is None
 
+
+@pytest.mark.django_db
+def test_pip_detail_renders_change_content_as_markdown(maria, released_pb):
+    wf = Workflow.objects.create(name="BPE", playbook=released_pb, order=1)
+    pip = PIPService.create_draft_for_playbook(
+        actor=maria, playbook_id=released_pb.pk, title="Markdown detail",
+    )
+    PIPService.add_change(
+        actor=maria,
+        pip=pip,
+        change_type=PipChange.CHANGE_ADD,
+        entity_type=PipChange.ENTITY_ACTIVITY,
+        name="Feature Gate",
+        content="## Feature Gate\n\n**Cursor skill:** `dev-0-feature-gate`",
+        parent_workflow_id=wf.pk,
+    )
+    client = Client()
+    client.force_login(maria)
+    rsp = client.get(reverse("pip_detail", kwargs={"pk": pip.pk}))
+    body = rsp.content.decode()
+    assert rsp.status_code == 200
+    assert 'class="markdown-content' in body
+    assert "<h2>Feature Gate</h2>" in body
+    assert "<strong>Cursor skill:</strong>" in body
+
+
+@pytest.mark.django_db
+def test_pip_preview_renders_change_content_as_markdown(maria, released_pb):
+    wf = Workflow.objects.create(name="BPE", playbook=released_pb, order=1)
+    pip = PIPService.create_draft_for_playbook(
+        actor=maria, playbook_id=released_pb.pk, title="Markdown preview",
+    )
+    PIPService.add_change(
+        actor=maria,
+        pip=pip,
+        change_type=PipChange.CHANGE_ADD,
+        entity_type=PipChange.ENTITY_ACTIVITY,
+        name="Plan Testability",
+        content="## Plan Testability\n\nManual-only skill for test planning.",
+        parent_workflow_id=wf.pk,
+    )
+    client = Client()
+    client.force_login(maria)
+    rsp = client.get(reverse("pip_preview", kwargs={"pk": pip.pk}))
+    body = rsp.content.decode()
+    assert rsp.status_code == 200
+    assert 'data-testid="pip-preview-content"' in body
+    assert "<h2>Plan Testability</h2>" in body
+


### PR DESCRIPTION
## Summary
- PIP detail and preview pages now render change content through the same `markdown` filter used on activity guidance pages, instead of dumping raw markdown into `<pre>` blocks.
- Preview layout switched from a snippet table to cards with scrollable rendered content for long activity bodies.
- Added shared `markdown_content_assets.html` include (Mermaid init + `.markdown-content` styles).

## Test plan
- [x] `pytest tests/integration/test_pip_create_views.py::test_pip_detail_renders_change_content_as_markdown`
- [x] `pytest tests/integration/test_pip_create_views.py::test_pip_preview_renders_change_content_as_markdown`
- [x] Open a PIP with ADD/ALTER Activity changes (e.g. large SKILL.md bodies) and confirm headings, bold, lists, and code blocks render on detail and preview pages