### PR TITLE
feat(ui): render entity descriptions as Markdown

### DIFF
--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -139,3 +139,68 @@ body.mm-landing footer {
     margin-bottom: 0.6rem;
     width: 2.25rem;
 }
+
+/* Markdown-rendered content (descriptions, guidance, etc.) */
+.markdown-content {
+    line-height: 1.6;
+}
+
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.markdown-content h1 { font-size: 1.75rem; }
+.markdown-content h2 { font-size: 1.5rem; }
+.markdown-content h3 { font-size: 1.25rem; }
+
+.markdown-content pre {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 0.25rem;
+    padding: 1rem;
+    overflow-x: auto;
+}
+
+.markdown-content code {
+    background-color: #f8f9fa;
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.25rem;
+    font-size: 0.875em;
+}
+
+.markdown-content pre code {
+    background-color: transparent;
+    padding: 0;
+}
+
+.markdown-content img {
+    max-width: 100%;
+    height: auto;
+}
+
+.markdown-content table {
+    width: 100%;
+    margin-bottom: 1rem;
+    border-collapse: collapse;
+}
+
+.markdown-content table th,
+.markdown-content table td {
+    padding: 0.75rem;
+    border: 1px solid #dee2e6;
+}
+
+.markdown-content table thead th {
+    background-color: #f8f9fa;
+    font-weight: 600;
+}
+
+.markdown-content > :last-child {
+    margin-bottom: 0;
+}

--- a/templates/activities/create.html
+++ b/templates/activities/create.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}Create Activity - {{ workflow.name }}{% endblock %}
 
@@ -95,7 +96,7 @@
                                 <option value="">-- No Phase --</option>
                                 {% for phase in available_phases %}
                                 <option value="{{ phase.id }}" {% if form_data.phase|stringformat:"s" == phase.id|stringformat:"s" %}selected{% endif %}>
-                                    {{ phase.name }}{% if phase.description %} - {{ phase.description }}{% endif %}
+                                    {{ phase.name }}{% if phase.description %} - {{ phase.description|markdown|striptags|truncatewords:10 }}{% endif %}
                                 </option>
                                 {% endfor %}
                             </select>

--- a/templates/activities/detail.html
+++ b/templates/activities/detail.html
@@ -152,7 +152,7 @@
                 </div>
                 <div class="card-body">
                     <h6 class="card-title">{{ workflow.name }}</h6>
-                    <p class="card-text small text-muted">{{ workflow.description|truncatewords:20 }}</p>
+                    <p class="card-text small text-muted">{{ workflow.description|markdown|striptags|truncatewords:20 }}</p>
                     <a href="{% url 'workflow_detail' playbook_pk=playbook.pk pk=workflow.pk %}" 
                        class="btn btn-sm btn-outline-primary">
                         <i class="fa-solid fa-arrow-right"></i> View Workflow

--- a/templates/activities/edit.html
+++ b/templates/activities/edit.html
@@ -96,7 +96,7 @@
                                 <option value="">-- No Phase --</option>
                                 {% for phase in available_phases %}
                                 <option value="{{ phase.id }}" {% if form_data.phase|stringformat:"s" == phase.id|stringformat:"s" %}selected{% endif %}>
-                                    {{ phase.name }}{% if phase.description %} - {{ phase.description }}{% endif %}
+                                    {{ phase.name }}{% if phase.description %} - {{ phase.description|markdown|striptags|truncatewords:10 }}{% endif %}
                                 </option>
                                 {% endfor %}
                             </select>

--- a/templates/artifacts/_embed.html
+++ b/templates/artifacts/_embed.html
@@ -1,4 +1,5 @@
 <div class="card" data-testid="artifact-embed">
+{% load markdown_filters %}
   <div class="card-header d-flex justify-content-between align-items-center">
     <h5 class="mb-0">
       <i class="fa-solid fa-gift me-1"></i>
@@ -13,7 +14,7 @@
   </div>
   <div class="card-body">
     {% if artifact.description %}
-    <p class="card-text text-muted mb-3" data-testid="embed-description">{{ artifact.description }}</p>
+    <div class="markdown-content card-text text-muted mb-3" data-testid="embed-description">{{ artifact.description|markdown }}</div>
     {% endif %}
 
     <dl class="row mb-0 small">

--- a/templates/artifacts/detail.html
+++ b/templates/artifacts/detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}{{ artifact.name }} - Artifact{% endblock %}
 
@@ -47,8 +48,8 @@
                 <div class="card-header">
                     <h5 class="mb-0"><i class="fa-solid fa-align-left"></i> Description</h5>
                 </div>
-                <div class="card-body" data-testid="artifact-description">
-                    <p class="mb-0">{{ artifact.description }}</p>
+                <div class="card-body markdown-content" data-testid="artifact-description">
+                    {{ artifact.description|markdown }}
                 </div>
             </div>
             {% endif %}

--- a/templates/methodology/partials/my_playbooks_section.html
+++ b/templates/methodology/partials/my_playbooks_section.html
@@ -1,5 +1,6 @@
 {# templates/methodology/partials/my_playbooks_section.html #}
 {# My Playbooks section partial for dashboard #}
+{% load markdown_filters %}
 
 <div class="col-lg-6 mb-4" data-testid="my-playbooks-section">
     <div class="card h-100">
@@ -31,7 +32,7 @@
                                     <i class="fas fa-code-branch"></i> v{{ playbook.version }}
                                 </small>
                                 {% if playbook.description %}
-                                <p class="text-muted small mb-0 mt-1 dashboard-playbook-description">{{ playbook.description|truncatechars:80 }}</p>
+                                <p class="text-muted small mb-0 mt-1 dashboard-playbook-description">{{ playbook.description|markdown|striptags|truncatechars:80 }}</p>
                                 {% endif %}
                             </div>
                             <div class="text-end flex-shrink-0">

--- a/templates/phases/detail.html
+++ b/templates/phases/detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load markdown_filters %}
 
 {% block title %}{{ phase.name }} - {{ playbook.name }}{% endblock %}
 
@@ -57,11 +58,11 @@
                 <div class="card-header">
                     <h5 class="mb-0"><i class="fa-solid fa-info-circle"></i> Description</h5>
                 </div>
-                <div class="card-body" data-testid="phase-description">
+                <div class="card-body markdown-content" data-testid="phase-description">
                     {% if phase.description %}
-                    <p>{{ phase.description }}</p>
+                    {{ phase.description|markdown }}
                     {% else %}
-                    <p class="text-muted fst-italic">No description provided</p>
+                    <p class="text-muted fst-italic mb-0">No description provided</p>
                     {% endif %}
                 </div>
             </div>

--- a/templates/phases/list.html
+++ b/templates/phases/list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load markdown_filters %}
 
 {% block title %}Phases - {{ playbook.name }}{% endblock %}
 
@@ -43,7 +44,7 @@
                                 {{ phase.name }}
                             </h5>
                             {% if phase.description %}
-                            <p class="card-text text-muted">{{ phase.description|truncatewords:20 }}</p>
+                            <p class="card-text text-muted">{{ phase.description|markdown|striptags|truncatewords:20 }}</p>
                             {% else %}
                             <p class="card-text text-muted fst-italic">No description</p>
                             {% endif %}

--- a/templates/phases/list_global.html
+++ b/templates/phases/list_global.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}Phases{% endblock %}
 
@@ -87,7 +88,7 @@
                             </a>
                         </td>
                         <td class="text-muted small">{{ phase.order }}</td>
-                        <td class="text-muted small">{{ phase.description|truncatewords:10 }}</td>
+                        <td class="text-muted small">{{ phase.description|markdown|striptags|truncatewords:10 }}</td>
                         <td>
                             <a href="{% url 'phase_detail' playbook_pk=phase.playbook.id phase_pk=phase.id %}"
                                class="btn btn-outline-primary btn-sm"

--- a/templates/playbooks/_embed.html
+++ b/templates/playbooks/_embed.html
@@ -1,4 +1,5 @@
 <div class="card" data-testid="playbook-embed">
+{% load markdown_filters %}
   <div class="card-header d-flex justify-content-between align-items-center">
     <h5 class="mb-0">
       <i class="fa-solid fa-book-sparkles me-1"></i>
@@ -10,7 +11,7 @@
   </div>
   <div class="card-body">
     {% if playbook.description %}
-    <p class="card-text text-muted mb-3">{{ playbook.description }}</p>
+    <div class="markdown-content card-text text-muted mb-3">{{ playbook.description|markdown }}</div>
     {% endif %}
     <dl class="row mb-0 small">
       <dt class="col-5">Category</dt>

--- a/templates/playbooks/_playbook_list_card.html
+++ b/templates/playbooks/_playbook_list_card.html
@@ -1,4 +1,5 @@
 {# Unified playbook card for owned and browsable public playbooks. #}
+{% load markdown_filters %}
 <div class="col-md-6 col-lg-4 mb-4">
     <div class="playbook-book-card h-100"
          data-testid="{% if playbook.author == request.user %}playbook-book-card{% else %}public-playbook-card{% endif %}-{{ playbook.pk }}">
@@ -26,7 +27,7 @@
             <div class="card-body pt-3 pb-0 d-flex flex-column flex-grow-1">
                 {% if playbook.description %}
                     <p class="card-text text-muted small playbook-book-card-description mb-0">
-                        {{ playbook.description|truncatewords:42 }}
+                        {{ playbook.description|markdown|striptags|truncatewords:42 }}
                     </p>
                 {% else %}
                     <p class="card-text text-muted small playbook-book-card-description mb-0 fst-italic">

--- a/templates/playbooks/create_wizard_step3.html
+++ b/templates/playbooks/create_wizard_step3.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}Create Playbook - Step 3{% endblock %}
 
@@ -54,7 +55,7 @@
                 <dd class="col-sm-9">{{ wizard_data.name }}</dd>
 
                 <dt class="col-sm-3">Description:</dt>
-                <dd class="col-sm-9">{{ wizard_data.description }}</dd>
+                <dd class="col-sm-9 markdown-content">{{ wizard_data.description|markdown }}</dd>
 
                 <dt class="col-sm-3">Category:</dt>
                 <dd class="col-sm-9">{{ wizard_data.category|title }}</dd>

--- a/templates/playbooks/detail.html
+++ b/templates/playbooks/detail.html
@@ -195,8 +195,12 @@
                 <div class="card-header">
                     <h5 class="mb-0"><i class="fa-solid fa-align-left"></i> Description</h5>
                 </div>
-                <div class="card-body">
-                    <p>{{ playbook.description }}</p>
+                <div class="card-body markdown-content" data-testid="playbook-description">
+                    {% if playbook.description %}
+                        {{ playbook.description|markdown }}
+                    {% else %}
+                        <p class="text-muted fst-italic mb-0">No description provided.</p>
+                    {% endif %}
                 </div>
             </div>
 
@@ -310,7 +314,7 @@
                                                class="text-decoration-none fw-semibold"
                                                data-testid="workflow-name-link-{{ workflow.pk }}">{{ workflow.name }}</a>
                                             {% if workflow.description %}
-                                                <p class="mb-0 text-muted small">{{ workflow.description }}</p>
+                                                <p class="mb-0 text-muted small">{{ workflow.description|markdown|striptags|truncatewords:20 }}</p>
                                             {% endif %}
                                         </li>
                                     {% endfor %}
@@ -391,7 +395,7 @@
                         <span class="badge bg-info">{{ phase.get_activity_count }} activities</span>
                     </div>
                     {% if phase.description %}
-                    <p class="mb-0 text-muted small mt-1">{{ phase.description|truncatewords:20 }}</p>
+                    <p class="mb-0 text-muted small mt-1">{{ phase.description|markdown|striptags|truncatewords:20 }}</p>
                     {% endif %}
                 </a>
                 {% endfor %}

--- a/templates/search/results.html
+++ b/templates/search/results.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load markdown_filters %}
 
 {% block title %}Search results - Mimir{% endblock %}
 
@@ -77,7 +78,7 @@
                         <div class="fw-bold">
                             <a href="{% url 'playbook_detail' playbook.pk %}">{{ playbook.name }}</a>
                         </div>
-                        <small class="text-muted">{{ playbook.description }}</small>
+                        <small class="text-muted">{{ playbook.description|markdown|striptags|truncatewords:20 }}</small>
                     </div>
                 </li>
                 {% empty %}
@@ -99,7 +100,7 @@
                         <div class="fw-bold">
                             <a href="{% url 'workflow_detail' workflow.playbook.pk workflow.pk %}">{{ workflow.name }}</a>
                         </div>
-                        <small class="text-muted">{{ workflow.description }}</small>
+                        <small class="text-muted">{{ workflow.description|markdown|striptags|truncatewords:20 }}</small>
                     </div>
                 </li>
                 {% empty %}

--- a/templates/teams/browse.html
+++ b/templates/teams/browse.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}Teams{% endblock %}
 
@@ -126,7 +127,7 @@
                             {{ team.visibility }}
                         </span>
                     </div>
-                    <p class="card-text text-muted small mb-3">{{ team.description }}</p>
+                    <p class="card-text text-muted small mb-3">{{ team.description|markdown|striptags|truncatewords:25 }}</p>
                     <div class="d-flex gap-3 text-muted small mb-3">
                         <span data-bs-toggle="tooltip" title="Members">
                             <i class="fa-solid fa-user-group me-1"></i>

--- a/templates/teams/detail.html
+++ b/templates/teams/detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}{{ team.name }}{% endblock %}
 
@@ -106,7 +107,7 @@
                 <div class="card-body">
                     <h6 class="text-muted text-uppercase small fw-semibold mb-3">About</h6>
                     {% if team.description %}
-                    <p class="mb-3">{{ team.description }}</p>
+                    <div class="markdown-content mb-3">{{ team.description|markdown }}</div>
                     {% else %}
                     <p class="text-muted fst-italic mb-3">No description provided.</p>
                     {% endif %}

--- a/templates/workflows/_embed.html
+++ b/templates/workflows/_embed.html
@@ -1,4 +1,5 @@
 <div class="card" data-testid="workflow-embed">
+{% load markdown_filters %}
   <div class="card-header">
     <h5 class="mb-0">
       <i class="fa-solid fa-diagram-project me-1"></i>
@@ -10,7 +11,7 @@
   </div>
   <div class="card-body">
     {% if workflow.description %}
-    <p class="card-text text-muted mb-3">{{ workflow.description }}</p>
+    <div class="markdown-content card-text text-muted mb-3">{{ workflow.description|markdown }}</div>
     {% endif %}
     <dl class="row mb-0 small">
       <dt class="col-5">Activities</dt>

--- a/templates/workflows/detail.html
+++ b/templates/workflows/detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}{{ workflow.name }} - {{ playbook.name }}{% endblock %}
 
@@ -78,7 +79,7 @@
     <div class="card mb-4">
         <div class="card-body">
             <h5 class="card-title">Description</h5>
-            <p class="card-text" data-testid="workflow-description">{{ workflow.description }}</p>
+            <div class="card-text markdown-content" data-testid="workflow-description">{{ workflow.description|markdown }}</div>
         </div>
     </div>
     {% endif %}

--- a/templates/workflows/list.html
+++ b/templates/workflows/list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load markdown_filters %}
 
 {% block title %}Workflows - {{ playbook.name }}{% endblock %}
 
@@ -71,7 +72,7 @@
                             {{ workflow.name }}
                         </a>
                     </td>
-                    <td>{{ workflow.description|truncatewords:10 }}</td>
+                    <td>{{ workflow.description|markdown|striptags|truncatewords:10 }}</td>
                     <td>{{ workflow.get_activity_count }}</td>
                     <td>
                         <div class="btn-group btn-group-sm" role="group">


### PR DESCRIPTION
## Summary
- Render playbook, workflow, phase, artifact, and team descriptions as Markdown on detail pages, embed panels, and wizard review steps
- Strip Markdown to plain text before truncating in list cards, search results, and browse views
- Add shared `.markdown-content` styles to the design system for consistent formatting

## Test plan
- [x] Open a playbook detail page with Markdown in the description (bold, lists, links) and confirm formatted output
- [ ] Verify playbook list cards and search results show clean truncated plain text (no raw `**` or HTML tags)
- [x] Check workflow, phase, artifact, and team detail pages render Markdown descriptions correctly
- [x] Confirm edit forms still show raw Markdown source in textareas