### PR TITLE
chore(dev): add personal mimir.dev.db sandbox for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,10 @@ GALDR_MODEL=claude-sonnet-4-5
 USE_SES_IN_DEV=0                    # 0 = print to terminal (no inbox delivery); 1 = real SES delivery
 
 # ── Database ──────────────────────────────────────────────────────────────────
-# Default: SQLite at mimir.db (dev). Set DATABASE_URL for Postgres.
+# Personal local sandbox — gitignored (*.db except committed mimir.db seed).
+# First time: make dev-db-init  |  After git pull updates seed: make refresh-dev-db
+MIMIR_DB_PATH=mimir.dev.db
+# Omit MIMIR_DB_PATH to use committed mimir.db directly (not recommended for daily dev).
 # DATABASE_URL=postgresql://mimir:password@localhost:5432/mimir
 
 # ── AWS (ECR / SES / EB — CI/CD and prod only) ───────────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -224,8 +224,8 @@ tests.log
 *.sqlite3
 *.db
 !mimir.db
-mimir.db-shm
-mimir.db-wal
+*.db-shm
+*.db-wal
 
 
 # Application logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,9 @@ Both processes share the same SQLite DB with a 20-second timeout for concurrent 
 
 **Bug reports (production):** Configure **`GITHUB_TOKEN`** (Issues: write) and optional **`GITHUB_BUG_REPO`** on the **FOB** host (Elastic Beanstalk environment properties or `docker-compose` web service). See [`docs/architecture/SAO.md`](docs/architecture/SAO.md) § *Bug reports — GitHub Issues*. The MCP facade does not need this token.
 
-**Contributors:** `mimir.db` is tracked in git; when migrations or committed demo data change the DB file, **commit `mimir.db` in the same change**—do not drop it from PRs by habit.
+**Contributors:** `mimir.db` is tracked in git as the **shared seed** (FeatureFactory playbook, baseline data). When migrations or seed content change, **commit `mimir.db` in the same change**—do not drop it from PRs by habit.
+
+**Local development:** Set `MIMIR_DB_PATH=mimir.dev.db` in `.env` (see `.env.example`). Run `make dev-db-init` once, then `make run` / `make mcp` against your personal DB. After pull updates seed: `make refresh-dev-db`. Do not commit `mimir.dev.db`.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ provision: ## Python venv + deps, migrations, dark-factory CLI tools, verify
 	@echo "Provision complete."
 	@echo "  App:  make run"
 	@echo "  MCP:  make mcp"
+	@echo "  Personal DB (once): make dev-db-init   # needs MIMIR_DB_PATH in .env"
 	@echo "  Factory: scripts/preflight.sh '<milestone>' then scripts/factory.sh '<slug>'"
 
 .PHONY: factory-check
@@ -67,10 +68,10 @@ demo: ## Load demo FeatureFactory data
 	$(PYTHON) manage.py create_demo_fdd
 
 ##@ Testing
-
-export DJANGO_SETTINGS_MODULE ?= mimir.settings.test
+# Test settings only for test targets — do not export globally (breaks make run → mimir_test.db).
 
 .PHONY: test
+test: export DJANGO_SETTINGS_MODULE := mimir.settings.test
 test: ## Run all tests (mirrors CI)
 	$(PYTEST) tests/ \
 	  --ignore=tests/e2e \
@@ -80,10 +81,12 @@ test: ## Run all tests (mirrors CI)
 	  --ignore=tests/unit/test_activity_graph_service.py
 
 .PHONY: test-unit
+test-unit: export DJANGO_SETTINGS_MODULE := mimir.settings.test
 test-unit: ## Run unit tests only
 	$(PYTEST) tests/unit/
 
 .PHONY: test-integration
+test-integration: export DJANGO_SETTINGS_MODULE := mimir.settings.test
 test-integration: ## Run integration tests only
 	$(PYTEST) tests/integration/ \
 	  --ignore=tests/integration/test_mcp_server_acceptance.py \
@@ -91,6 +94,7 @@ test-integration: ## Run integration tests only
 	  --ignore=tests/integration/test_mcp_e2e_all_tools.py
 
 .PHONY: test-e2e
+test-e2e: export DJANGO_SETTINGS_MODULE := mimir.settings.test
 test-e2e: ## Run Playwright E2E tests (requires running server)
 	$(PYTEST) tests/e2e/
 
@@ -110,13 +114,39 @@ lint-fix: ## Run ruff linter with auto-fix
 	$(RUFF) check --fix .
 
 ##@ Database
-# Local dev uses SQLite (mimir.db). Production on EB uses Postgres (DATABASE_URL env var).
+# Committed seed: mimir.db. Personal sandbox: mimir.dev.db via MIMIR_DB_PATH in .env.
+# Production on EB uses Postgres (DATABASE_URL env var).
+
+.PHONY: dev-db-init
+dev-db-init: ## [local] Copy seed mimir.db → mimir.dev.db (first-time personal sandbox)
+	@if [ -f mimir.dev.db ]; then \
+	  echo "mimir.dev.db already exists — use 'make refresh-dev-db' to reset from seed."; \
+	  exit 1; \
+	fi
+	cp mimir.db mimir.dev.db
+	@echo "Created mimir.dev.db from mimir.db."
+	@echo "Set MIMIR_DB_PATH=mimir.dev.db in .env (see .env.example), then: make run"
+
+.PHONY: refresh-dev-db
+refresh-dev-db: ## [local] Overwrite mimir.dev.db from seed mimir.db and run migrations
+	cp mimir.db mimir.dev.db
+	$(PYTHON) manage.py migrate --noinput
+	@echo "mimir.dev.db refreshed from committed seed (mimir.db)."
+
+.PHONY: dev-db-reset
+dev-db-reset: ## [local] Delete mimir.dev.db and recreate from seed mimir.db
+	@echo "WARNING: This will delete mimir.dev.db and all personal local data."
+	@read -p "Continue? [y/N] " ans && [ "$$ans" = "y" ]
+	rm -f mimir.dev.db mimir.dev.db-shm mimir.dev.db-wal
+	cp mimir.db mimir.dev.db
+	$(PYTHON) manage.py migrate --noinput
+	@echo "mimir.dev.db recreated from seed."
 
 .PHONY: db-reset
-db-reset: ## [local] Delete mimir.db and re-run migrations (destroys all local data)
-	@echo "WARNING: This will delete mimir.db and all local data."
+db-reset: ## [local] Delete mimir.db and re-run migrations (destroys committed seed file — rare)
+	@echo "WARNING: This will delete mimir.db and all data in the seed database."
 	@read -p "Continue? [y/N] " ans && [ "$$ans" = "y" ]
-	rm -f mimir.db
+	rm -f mimir.db mimir.db-shm mimir.db-wal
 	$(PYTHON) manage.py migrate --noinput
 	@echo "Database reset. Run 'make demo' to reload demo data."
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Maintainers publishing from CI configure GitHub Actions secrets **`DOCKERHUB_USE
    cp .env.example .env   # edit values as needed (email, API keys, etc.)
    ```
 
+   `.env.example` sets `MIMIR_DB_PATH=mimir.dev.db` so daily work stays in a **personal SQLite file** (gitignored). The committed `mimir.db` remains the shared seed only.
+
    Without a local `.env`, dev defaults may differ from `.env.example` (e.g. email via AWS SES instead of the console backend).
 
 3. **Create virtual environment**
@@ -177,9 +179,12 @@ Maintainers publishing from CI configure GitHub Actions secrets **`DOCKERHUB_USE
 5. **Initialize database**
    ```bash
    python manage.py migrate
+   make dev-db-init    # once: copies seed mimir.db → mimir.dev.db
    ```
-   
-   **Note:** The default database (`mimir.db`) includes the **FeatureFactory** playbook, which was used to build Mimir itself. This playbook provides a complete feature development workflow with 8 activities covering planning, implementation, testing, and finalization.
+
+   **Note:** Committed `mimir.db` includes the **FeatureFactory** playbook (the workflow used to build Mimir). With `MIMIR_DB_PATH=mimir.dev.db` in `.env`, `make run` and `make mcp` use your personal copy; git will not track local users or experiments.
+
+   After `git pull` updates the seed, refresh your sandbox: `make refresh-dev-db`.
 
 6. **Ensure local superuser**
 
@@ -223,19 +228,20 @@ Maintainers publishing from CI configure GitHub Actions secrets **`DOCKERHUB_USE
 
 ```bash
 # Start web UI (keep running in terminal)
-python manage.py runserver 8000
+make run
 # → Open http://localhost:8000
 
 # Test MCP server manually (different terminal)
-python manage.py mcp_server --user=admin
+make mcp
 # → Press Ctrl+C to stop
+
+# Personal DB (MIMIR_DB_PATH=mimir.dev.db in .env)
+make dev-db-init      # once: copy seed → mimir.dev.db
+make refresh-dev-db   # after pull: re-sync from committed mimir.db
+make dev-db-reset     # wipe personal DB and recreate from seed
 
 # Run all tests
 pytest tests/
-# → Should see: 250 passed, 1 skipped
-
-# Create a new user
-python manage.py createsuperuser
 ```
 
 ### MCP Configuration Files

--- a/docs/architecture/SAO.md
+++ b/docs/architecture/SAO.md
@@ -319,7 +319,7 @@ python manage.py runserver 8000
 - PIP review and approval
 
 **Shared SQLite Database**:
-- Both processes connect to same `mimir.db`
+- Web UI and MCP connect to the same SQLite file (`mimir.db` seed, or `MIMIR_DB_PATH` e.g. `mimir.dev.db` for personal dev)
 - SQLite handles concurrent access (timeout: 20s)
 - Minimal write conflicts (MCP reads, Web UI writes)
 - No complex coordination needed
@@ -2131,8 +2131,8 @@ Complete reference for all environment variables consumed by Mimir, grouped by e
 | `AWS_SES_REGION_NAME` | If SES | `us-east-1` | Required when `USE_SES_IN_DEV=1` |
 | `DEFAULT_FROM_EMAIL` | If SES | `noreply@featurefactory.io` | Must be SES-verified |
 | `AWS_SES_CONFIGURATION_SET` | No | `mimir-transactional` | SES configuration set for bounce/open tracking |
-| `DATABASE_URL` | No | — | If set, uses Postgres via `dj-database-url`; otherwise SQLite at `mimir.db` |
-| `MIMIR_DB_PATH` | No | — | Override SQLite path (used in Docker) |
+| `DATABASE_URL` | No | — | If set, uses Postgres via `dj-database-url`; otherwise SQLite |
+| `MIMIR_DB_PATH` | No | `mimir.db` (or `data/mimir.db` in Docker) | SQLite path; use `mimir.dev.db` locally (see `.env.example`, `make dev-db-init`) |
 | `FRONTEND_URL` | No | `http://localhost:8000` | Used in email links |
 | `MIMIR_MCP_MODE` | No | `1` | Set by MCP server startup; suppresses console logging on stdio |
 

--- a/mimir/settings/dev.py
+++ b/mimir/settings/dev.py
@@ -64,8 +64,10 @@ else:
     # Support for volume-mounted database in Docker container
     db_path = os.getenv('MIMIR_DB_PATH')
     if db_path:
-        # Use environment variable path (for Docker)
+        # Docker uses absolute paths; local dev may use repo-relative names (e.g. mimir.dev.db)
         database_path = Path(db_path)
+        if not database_path.is_absolute():
+            database_path = BASE_DIR / database_path  # noqa: F405
     else:
         # Check if we're in containerized environment (data directory exists)
         data_dir = BASE_DIR / "data"  # noqa: F405


### PR DESCRIPTION
## Summary

- Adds a **personal local SQLite sandbox** (`mimir.dev.db`) so daily dev experiments stay gitignored while committed `mimir.db` remains the shared seed.
- Introduces `MIMIR_DB_PATH` in `.env.example` and resolves relative DB paths in `mimir/settings/dev.py`.
- Adds Makefile targets: `dev-db-init`, `refresh-dev-db`, `dev-db-reset`.
- Scopes `DJANGO_SETTINGS_MODULE=mimir.settings.test` to test targets only so `make run` / `make mcp` use the dev database.
- Updates README, CLAUDE.md, and SAO.md with the workflow.

## Test plan

- [x] `make dev-db-init` creates `mimir.dev.db` from seed
- [x] With `MIMIR_DB_PATH=mimir.dev.db` in `.env`, `make run` and `make mcp` read/write personal DB
- [x] `make refresh-dev-db` re-syncs from committed `mimir.db`
- [x] `make test` still uses test settings (not dev DB)
- [x] `mimir.dev.db` is gitignored; `mimir.db` remains tracked