### PR TITLE
fix(workflows): export via JSON contents; facade writes locally

### DIFF
--- a/docs/features/act-3-workflows/workflows-export-import.feature
+++ b/docs/features/act-3-workflows/workflows-export-import.feature
@@ -13,11 +13,20 @@ Feature: FOB-WORKFLOWS-EXPORT_IMPORT-1 MCP Workflow Synchronization
   ✅ Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-01 Export via MCP tool
     Given Maria's AI assistant has access to Mimir MCP server
     When AI calls mcp.export_workflow_to_local(workflow_id=42, target_directory=".windsurf/workflows", folder_name="FFE")
-    Then the MCP server exports the workflow
+    Then the MCP facade receives file contents from the server
+    And the facade writes files to the AI workspace at ".windsurf/workflows/FFE/"
     And returns success response with export path and file list
     And 16 files are created in ".windsurf/workflows/FFE/"
     And folder contains "_workflow.md" with workflow metadata
     And folder contains 15 activity files: FFE-01-*.md through FFE-15-*.md
+
+  ✅ Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-01c Hosted server returns file contents, not a path
+    Given Maria's AI assistant uses the HTTP MCP facade against a hosted FOB server
+    When AI calls mcp.export_workflow_to_local(workflow_id=42, target_directory=".windsurf/workflows", folder_name="FFE")
+    Then the server response contains a "workflow_files" array with "filename" and "content" pairs
+    And the server response does not contain an "export_path" key
+    And the facade computes the local export path under ".windsurf/workflows/FFE/"
+    And the tool return value includes that local "export_path" and "files_created" list
 
   Scenario: FOB-WORKFLOWS-EXPORT_IMPORT-01b Export writes rules to sibling rules folder
     Given activities in the workflow link playbook rules "pytest" and "ruff"

--- a/docs/plans/export_fix.md
+++ b/docs/plans/export_fix.md
@@ -1,0 +1,184 @@
+---
+
+name: Fix export_workflow_to_local
+overview: "Split the export into two concerns: the server generates file contents (no I/O), returns them as JSON, and the local MCP facade writes the files to the user's machine."
+todos:
+
+- id: add-generate-method
+content: "Add WorkflowExportService.generate_workflow_files() — pure content generation, no filesystem I/O"
+status: completed
+- id: fix-viewset
+content: "Update viewsets.py export action to call generate_workflow_files() and return JSON"
+status: completed
+- id: fix-facade
+content: "Update tools_http.py export_workflow_to_local() to write files locally from JSON response"
+status: completed
+- id: unit-tests
+content: "Add unit tests for generate_workflow_files() in test_workflow_export_service.py"
+status: completed
+- id: integration-tests
+content: "Add integration tests for the new API endpoint shape in test_workflow_export_import_mcp.py"
+status: completed
+- id: e2e-tool-test
+content: "Strengthen test_48_export_workflow_to_local in test_mcp_e2e_all_tools.py to verify local file writes"
+status: completed
+- id: bdd-scenarios
+content: "Update workflows-export-import.feature scenario FOB-WORKFLOWS-EXPORT_IMPORT-01 to reflect local file writes via facade"
+status: completed
+isProject: false
+
+---
+
+
+
+# Fix `export_workflow_to_local` — server writes locally
+
+
+
+## Root cause
+
+`tools_http.py::export_workflow_to_local` POSTs to `/api/workflows/{id}/export/`.
+The Django viewset calls `WorkflowExportService.export_workflow_to_markdown()`, which calls `export_path.mkdir()` and `file.write_text()` on the **hosted server's** filesystem — never reaching the user's machine.
+The viewset even has a dead-end 501 fallback for exactly this failure (`'Export to filesystem not supported on hosted server'`).
+
+## Implementation — three production files
+
+**Repo for edits and tests:** `Z:\Documents\GitHub\mimir` (Mac host share, has `.env`).
+**MCP server process** runs from `C:\Users\denispetelin\mimir` (Windows-local clone) — it must be restarted after changes are deployed there, but editing happens in Z:.
+
+Run tests with: `.venv/Scripts/pytest tests/unit/test_workflow_export_service.py tests/integration/test_workflow_export_import_mcp.py` (no `.env` needed — test settings use SQLite).
+
+---
+
+
+
+### 1. `[methodology/services/workflow_export_service.py](Z:\Documents\GitHub\mimir\methodology\services\workflow_export_service.py)`
+
+Add `generate_workflow_files()` as a new static method. Reuses all existing private `_generate_*` methods but does zero filesystem I/O — returns file contents as plain lists.
+
+Return shape:
+
+```python
+{
+    "workflow_id": 42,
+    "workflow_name": "My Workflow",
+    "folder_name": "My_Workflow",
+    "workflow_files": [
+        {"filename": "_workflow.md", "content": "..."},
+        {"filename": "My_Workflow-01-First_Step.md", "content": "..."},
+    ],
+    "rule_files": [
+        {"filename": "my-rule.mdc", "content": "..."},
+    ],
+}
+```
+
+The existing `export_workflow_to_markdown()` is kept unchanged — still used by the Django-embedded ORM server (`mcp_integration/tools.py`).
+
+### 2. `[methodology/api/viewsets.py](Z:\Documents\GitHub\mimir\methodology\api\viewsets.py)` — `export` action (~line 533)
+
+Replace body to call `generate_workflow_files()` and return 200 JSON directly. Remove the now-dead `PermissionError/OSError` try/except.
+
+```python
+@action(detail=True, methods=['post'], permission_classes=[IsAuthenticated])
+def export(self, request, pk=None):
+    self.get_object()  # permission check
+    folder_name = request.data.get('folder_name')
+    from methodology.services.workflow_export_service import WorkflowExportService
+    result = WorkflowExportService.generate_workflow_files(
+        workflow_id=pk,
+        folder_name=folder_name,
+    )
+    return Response(result)
+```
+
+
+
+### 3. `[mcp_integration/facade/tools_http.py](Z:\Documents\GitHub\mimir\mcp_integration\facade\tools_http.py)` — `export_workflow_to_local()` (~line 306)
+
+Receive JSON, write files locally using `pathlib`. Add `from pathlib import Path` at top of file.
+
+```python
+def export_workflow_to_local(workflow_id, target_directory=".windsurf/workflows", folder_name=None):
+    payload = {}
+    if folder_name:
+        payload["folder_name"] = folder_name
+    r = get_client().post(f"/api/workflows/{workflow_id}/export/", json=payload)
+    data = check_response(r, "export_workflow_to_local")
+
+    wf_dir = Path(target_directory) / data["folder_name"]
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    for f in data["workflow_files"]:
+        (wf_dir / f["filename"]).write_text(f["content"], encoding="utf-8")
+
+    rule_files_written = []
+    if data.get("rule_files"):
+        rules_dir = Path(target_directory).resolve().parent / "rules"
+        rules_dir.mkdir(parents=True, exist_ok=True)
+        for f in data["rule_files"]:
+            (rules_dir / f["filename"]).write_text(f["content"], encoding="utf-8")
+            rule_files_written.append(f["filename"])
+
+    return {
+        "status": "exported",
+        "workflow_id": data["workflow_id"],
+        "workflow_name": data["workflow_name"],
+        "export_path": str(wf_dir),
+        "files_created": [f["filename"] for f in data["workflow_files"]],
+        "rule_files_created": rule_files_written,
+        "message": "Workflow exported successfully. Edit files locally and use import_workflow_from_local to apply changes.",
+    }
+```
+
+
+
+## Tests — four levels (BPE-01 planning)
+
+
+
+### Unit tests (thin) — `[tests/unit/test_workflow_export_service.py](Z:\Documents\GitHub\mimir\tests\unit\test_workflow_export_service.py)`
+
+Add a new `TestGenerateWorkflowFiles` class:
+
+- `test_generate_returns_file_contents` — result has `workflow_files`, `rule_files`, `folder_name`; `_workflow.md` content present; no filesystem side effects
+- `test_generate_with_rules` — activities with linked rules produce `rule_files` entries with `.mdc` YAML front matter
+- `test_generate_default_folder_name` — omitting `folder_name` uses slugified workflow name
+- `test_generate_nonexistent_workflow_raises` — `ObjectDoesNotExist` propagates
+
+Pure DB-read tests — no `tmp_path`, no `shutil`.
+
+### Integration tests (thick — main bet) — `[tests/integration/test_workflow_export_import_mcp.py](Z:\Documents\GitHub\mimir\tests\integration\test_workflow_export_import_mcp.py)`
+
+Add a new `TestWorkflowExportAPIShape` class using Django test client:
+
+- `test_export_endpoint_returns_json_not_files` — POST `/api/workflows/{id}/export/` returns 200 with `workflow_files` list; confirms no `export_path` key (server doesn't write files)
+- `test_export_endpoint_returns_correct_file_count` — `len(workflow_files)` == activity count + 1
+- `test_export_endpoint_rule_files_in_response` — activities with rules → non-empty `rule_files` with correct `.mdc` content
+- `test_export_endpoint_requires_auth` — unauthenticated POST → 401/403
+
+
+
+### E2E / facade test strengthening — `[tests/integration/test_mcp_e2e_all_tools.py](Z:\Documents\GitHub\mimir\tests\integration\test_mcp_e2e_all_tools.py)`
+
+Tighten `test_48_export_workflow_to_local` to assert that `tmp_path` actually contains a `_workflow.md` file after the call — not just "result is a dict".
+
+### BDD acceptance scenarios — `[docs/features/act-3-workflows/workflows-export-import.feature](Z:\Documents\GitHub\mimir\docs\features\act-3-workflows\workflows-export-import.feature)`
+
+Update scenario `FOB-WORKFLOWS-EXPORT_IMPORT-01`:
+
+- `Then the MCP server exports the workflow` → `Then the MCP facade receives file contents from the server`
+- Add: `And the facade writes files to the AI workspace at ".windsurf/workflows/FFE/"`
+
+Add new scenario `FOB-WORKFLOWS-EXPORT_IMPORT-01c Hosted server returns file contents, not a path`:
+
+- Server response contains `workflow_files` array with `filename`/`content` pairs but no `export_path`
+- Facade computes the local path; that path appears in the tool's final return value
+
+
+
+## No changes needed
+
+- `facade/server.py` — tool registration unchanged
+- `mcp_integration/tools.py` — ORM version keeps calling `export_workflow_to_markdown()` directly; writes locally as before
+- `import_workflow_from_local` — symmetric hosted-write problem exists but is out of scope
+

--- a/mcp_integration/facade/tools_http.py
+++ b/mcp_integration/facade/tools_http.py
@@ -9,6 +9,7 @@ No Django, no ORM — only the standard library + httpx.
 """
 import logging
 import os
+from pathlib import Path
 from typing import Literal, Optional
 
 from mcp_integration.facade.client import get_client, check_response
@@ -316,12 +317,57 @@ def export_workflow_to_local(
     :param folder_name: Folder name. Example: "FFE" (defaults to workflow slug)
     :return: Export result with file paths and counts
     """
-    logger.info(f'HTTP Tool: export_workflow_to_local workflow={workflow_id}')
-    payload = {"target_directory": target_directory}
+    logger.info(
+        'HTTP Tool: export_workflow_to_local workflow=%s target=%s folder=%s',
+        workflow_id,
+        target_directory,
+        folder_name,
+    )
+    payload = {}
     if folder_name:
         payload["folder_name"] = folder_name
     r = get_client().post(f"/api/workflows/{workflow_id}/export/", json=payload)
-    return check_response(r, "export_workflow_to_local")
+    data = check_response(r, "export_workflow_to_local")
+
+    wf_dir = Path(target_directory) / data["folder_name"]
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    for file_entry in data["workflow_files"]:
+        (wf_dir / file_entry["filename"]).write_text(
+            file_entry["content"], encoding="utf-8"
+        )
+    logger.info(
+        'HTTP Tool: wrote %s workflow files to %s',
+        len(data["workflow_files"]),
+        wf_dir,
+    )
+
+    rule_files_written = []
+    if data.get("rule_files"):
+        rules_dir = Path(target_directory).resolve().parent / "rules"
+        rules_dir.mkdir(parents=True, exist_ok=True)
+        for file_entry in data["rule_files"]:
+            (rules_dir / file_entry["filename"]).write_text(
+                file_entry["content"], encoding="utf-8"
+            )
+            rule_files_written.append(file_entry["filename"])
+        logger.info(
+            'HTTP Tool: wrote %s rule files to %s',
+            len(rule_files_written),
+            rules_dir,
+        )
+
+    return {
+        "status": "exported",
+        "workflow_id": data["workflow_id"],
+        "workflow_name": data["workflow_name"],
+        "export_path": str(wf_dir),
+        "files_created": [f["filename"] for f in data["workflow_files"]],
+        "rule_files_created": rule_files_written,
+        "message": (
+            "Workflow exported successfully. Edit files locally and use "
+            "import_workflow_from_local to apply changes."
+        ),
+    }
 
 
 def import_workflow_from_local(

--- a/methodology/api/viewsets.py
+++ b/methodology/api/viewsets.py
@@ -539,24 +539,15 @@ class WorkflowViewSet(viewsets.ModelViewSet):
         """
         logger.info(f'API: export_workflow_to_local called - workflow_id={pk}')
 
-        workflow = self.get_object()
-        target_directory = request.data.get('target_directory', '.windsurf/workflows')
+        self.get_object()
         folder_name = request.data.get('folder_name')
-        
+
         from methodology.services.workflow_export_service import WorkflowExportService
 
-        try:
-            result = WorkflowExportService.export_workflow_to_markdown(
-                workflow_id=pk,
-                target_directory=target_directory,
-                folder_name=folder_name,
-            )
-        except (PermissionError, OSError) as exc:
-            return Response(
-                {'error': f'Export to filesystem not supported on hosted server: {exc}',
-                 'code': 'NOT_SUPPORTED'},
-                status=status.HTTP_501_NOT_IMPLEMENTED
-            )
+        result = WorkflowExportService.generate_workflow_files(
+            workflow_id=pk,
+            folder_name=folder_name,
+        )
         return Response(result)
     
     @action(detail=True, methods=['post'], permission_classes=[IsAuthenticated])

--- a/methodology/services/workflow_export_service.py
+++ b/methodology/services/workflow_export_service.py
@@ -107,6 +107,71 @@ class WorkflowExportService:
         
         logger.info(f"Export completed: {len(files_created)} files created at {export_path}")
         return result
+
+    @staticmethod
+    def generate_workflow_files(
+        workflow_id: int,
+        folder_name: Optional[str] = None,
+    ) -> dict:
+        """
+        Generate workflow export file contents without filesystem I/O.
+
+        :param workflow_id: Workflow ID. Example: 42
+        :param folder_name: Folder name. Example: "FFE" (defaults to workflow slug)
+        :return: Dict with workflow_files and rule_files content lists
+        :raises ObjectDoesNotExist: If workflow does not exist
+        """
+        logger.info(f"Generating workflow files for workflow {workflow_id}")
+
+        try:
+            workflow = Workflow.objects.select_related('playbook').get(pk=workflow_id)
+        except ObjectDoesNotExist:
+            logger.error(f"Workflow {workflow_id} not found")
+            raise ObjectDoesNotExist(f"Workflow with ID {workflow_id} does not exist")
+
+        activities = list(
+            workflow.activities.select_related('agent').prefetch_related('skills', 'rules')
+            .prefetch_related(
+                'output_artifacts',
+                'input_artifacts__artifact',
+                'rules',
+            )
+            .order_by('order')
+        )
+        logger.info(f"Found {len(activities)} activities in workflow '{workflow.name}'")
+
+        if not folder_name:
+            folder_name = WorkflowExportService._slugify(workflow.name)
+
+        workflow_files = []
+        workflow_md = WorkflowExportService._generate_workflow_metadata_md(
+            workflow, len(activities)
+        )
+        workflow_files.append({"filename": "_workflow.md", "content": workflow_md})
+
+        slug_prefix = folder_name
+        for activity in activities:
+            filename, content = WorkflowExportService._generate_activity_md(
+                activity, activity.order, slug_prefix
+            )
+            workflow_files.append({"filename": filename, "content": content})
+
+        rule_files = WorkflowExportService._generate_rule_files_for_workflow(activities)
+
+        result = {
+            "workflow_id": workflow_id,
+            "workflow_name": workflow.name,
+            "folder_name": folder_name,
+            "workflow_files": workflow_files,
+            "rule_files": rule_files,
+        }
+        logger.info(
+            "Generated %s workflow files and %s rule files for workflow %s",
+            len(workflow_files),
+            len(rule_files),
+            workflow_id,
+        )
+        return result
     
     @staticmethod
     def _generate_workflow_metadata_md(workflow, activity_count: int) -> str:
@@ -299,6 +364,30 @@ No additional notes.
             logger.info('Exported rule file %s', out)
 
         return rules_dir, rel_created
+
+    @staticmethod
+    def _generate_rule_files_for_workflow(activities) -> list:
+        """
+        Build rule file contents for activities without filesystem I/O.
+
+        :returns: List of {"filename": str, "content": str} dicts
+        """
+        seen = {}
+        for activity in activities:
+            for rule in activity.rules.all():
+                seen[rule.id] = rule
+        if not seen:
+            logger.info('No rules linked to workflow activities; skipping rule generation')
+            return []
+
+        rule_files = []
+        for rule in sorted(seen.values(), key=lambda r: r.slug):
+            fname = f'{rule.slug}.mdc'
+            body = WorkflowExportService._format_rule_mdc(rule)
+            rule_files.append({"filename": fname, "content": body})
+            logger.info('Generated rule file content for %s', fname)
+
+        return rule_files
 
     @staticmethod
     def _format_rule_mdc(rule) -> str:

--- a/tests/integration/test_mcp_e2e_all_tools.py
+++ b/tests/integration/test_mcp_e2e_all_tools.py
@@ -691,7 +691,16 @@ class TestMCPAllTools:
             "workflow_id": TestMCPAllTools.wf_id,
             "target_directory": export_dir
         })
-        assert "export_path" in result or "files_written" in result or isinstance(result, dict)
+        assert result.get("status") == "exported"
+        assert "export_path" in result
+        assert "_workflow.md" in result.get("files_created", [])
+
+        export_path = Path(result["export_path"])
+        assert export_path.exists()
+        workflow_md = export_path / "_workflow.md"
+        assert workflow_md.exists(), f"Expected _workflow.md at {workflow_md}"
+        assert workflow_md.read_text(encoding="utf-8").startswith("# ")
+
         TestMCPAllTools.export_dir = export_dir
         logger.info(f"✓ export_workflow_to_local → {result}")
 

--- a/tests/integration/test_workflow_export_import_mcp.py
+++ b/tests/integration/test_workflow_export_import_mcp.py
@@ -409,3 +409,125 @@ Run integration tests
         assert result['changes_count'] == 0, (
             f"Activity with null guidance must not be a false positive; got {result['changes_count']}"
         )
+
+
+@pytest.mark.django_db
+class TestWorkflowExportAPIShape:
+    """Integration tests for POST /api/workflows/{id}/export/ JSON response shape."""
+
+    @pytest.fixture
+    def user(self, django_user_model):
+        return django_user_model.objects.create_user(
+            username='maria',
+            email='maria@example.com',
+            password='testpass123',
+        )
+
+    @pytest.fixture
+    def client(self, user):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        return client
+
+    @pytest.fixture
+    def playbook(self, user):
+        return Playbook.objects.create(
+            name='React Frontend Development',
+            description='Modern React patterns',
+            category='development',
+            author=user,
+            status='draft',
+            version='0.5',
+        )
+
+    @pytest.fixture
+    def workflow(self, playbook):
+        return Workflow.objects.create(
+            name='Frontend Development',
+            description='Complete frontend development process',
+            playbook=playbook,
+            abbreviation='FFE',
+            order=1,
+        )
+
+    @pytest.fixture
+    def activities(self, workflow, create_test_phases):
+        phases = create_test_phases(workflow.playbook)
+        activities = []
+        for i in range(1, 4):
+            activity = Activity.objects.create(
+                workflow=workflow,
+                name=f'Activity {i}',
+                guidance=f'Guidance for activity {i}',
+                order=i,
+                phase=phases['Foundation'] if i == 1 else phases['Implementation'],
+            )
+            activities.append(activity)
+        return activities
+
+    def test_export_endpoint_returns_json_not_files(self, client, workflow, activities):
+        """POST /export/ returns 200 with workflow_files list; no export_path key."""
+        response = client.post(
+            f'/api/workflows/{workflow.id}/export/',
+            {'folder_name': 'FFE'},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        data = response.data
+        assert 'workflow_files' in data
+        assert isinstance(data['workflow_files'], list)
+        assert 'export_path' not in data
+        assert data['folder_name'] == 'FFE'
+
+    def test_export_endpoint_returns_correct_file_count(self, client, workflow, activities):
+        """len(workflow_files) == activity count + 1 (_workflow.md)."""
+        response = client.post(
+            f'/api/workflows/{workflow.id}/export/',
+            {'folder_name': 'FFE'},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert len(response.data['workflow_files']) == len(activities) + 1
+
+    def test_export_endpoint_rule_files_in_response(self, client, workflow, activities, playbook):
+        """Activities with rules produce rule_files with correct .mdc content."""
+        from methodology.models import Rule
+
+        rule = Rule.objects.create(
+            playbook=playbook,
+            title='Pytest rule',
+            slug='pytest-rule',
+            content='Use pytest for all tests.',
+            always_apply=True,
+        )
+        activities[0].rules.add(rule)
+
+        response = client.post(
+            f'/api/workflows/{workflow.id}/export/',
+            {'folder_name': 'FFE'},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert len(response.data['rule_files']) == 1
+        rule_file = response.data['rule_files'][0]
+        assert rule_file['filename'] == 'pytest-rule.mdc'
+        assert 'alwaysApply: true' in rule_file['content']
+        assert 'Use pytest' in rule_file['content']
+
+    def test_export_endpoint_requires_auth(self, workflow, activities):
+        """Unauthenticated POST returns 401 or 403."""
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        response = client.post(
+            f'/api/workflows/{workflow.id}/export/',
+            {'folder_name': 'FFE'},
+            format='json',
+        )
+
+        assert response.status_code in (401, 403)

--- a/tests/unit/test_workflow_export_service.py
+++ b/tests/unit/test_workflow_export_service.py
@@ -424,3 +424,102 @@ class TestWorkflowExportService:
         assert '## Skill' in content
         assert '## Artifacts Produced' in content
         assert '## Artifacts Consumed' in content
+
+
+@pytest.mark.django_db
+class TestGenerateWorkflowFiles:
+    """Test generate_workflow_files() — pure content generation, no filesystem I/O."""
+
+    @pytest.fixture
+    def playbook(self, django_user_model):
+        user = django_user_model.objects.create_user(
+            username='maria',
+            email='maria@example.com',
+            password='testpass123',
+        )
+        return Playbook.objects.create(
+            name='React Frontend Development',
+            description='Modern React patterns',
+            category='development',
+            author=user,
+            status='draft',
+            version='0.5',
+        )
+
+    @pytest.fixture
+    def workflow(self, playbook):
+        return Workflow.objects.create(
+            name='Frontend Development',
+            description='Complete frontend development process',
+            playbook=playbook,
+            abbreviation='FFE',
+            order=1,
+        )
+
+    @pytest.fixture
+    def activities(self, workflow, create_test_phases):
+        phases = create_test_phases(workflow.playbook)
+        activities = []
+        for i in range(1, 4):
+            activity = Activity.objects.create(
+                workflow=workflow,
+                name=f'Activity {i}',
+                guidance=f'Guidance for activity {i}',
+                order=i,
+                phase=phases['Foundation'] if i == 1 else phases['Implementation'],
+            )
+            activities.append(activity)
+        return activities
+
+    def test_generate_returns_file_contents(self, workflow, activities):
+        """Result has workflow_files, rule_files, folder_name; no filesystem side effects."""
+        result = WorkflowExportService.generate_workflow_files(
+            workflow_id=workflow.id,
+            folder_name='FFE',
+        )
+
+        assert result['workflow_id'] == workflow.id
+        assert result['workflow_name'] == workflow.name
+        assert result['folder_name'] == 'FFE'
+        assert 'workflow_files' in result
+        assert 'rule_files' in result
+        assert len(result['workflow_files']) == 4  # _workflow.md + 3 activities
+
+        workflow_md = next(
+            f for f in result['workflow_files'] if f['filename'] == '_workflow.md'
+        )
+        assert '# Frontend Development' in workflow_md['content']
+        assert 'Total Activities**: 3' in workflow_md['content']
+
+    def test_generate_with_rules(self, workflow, activities, playbook):
+        """Activities with linked rules produce rule_files entries with .mdc YAML front matter."""
+        rule = Rule.objects.create(
+            playbook=playbook,
+            title='Pytest rule',
+            slug='pytest-rule',
+            content='Use pytest for all tests.',
+            always_apply=True,
+        )
+        activities[0].rules.add(rule)
+
+        result = WorkflowExportService.generate_workflow_files(
+            workflow_id=workflow.id,
+            folder_name='FFE',
+        )
+
+        assert len(result['rule_files']) == 1
+        rule_file = result['rule_files'][0]
+        assert rule_file['filename'] == 'pytest-rule.mdc'
+        assert 'alwaysApply: true' in rule_file['content']
+        assert 'Use pytest' in rule_file['content']
+
+    def test_generate_default_folder_name(self, workflow, activities):
+        """Omitting folder_name uses slugified workflow name."""
+        result = WorkflowExportService.generate_workflow_files(workflow_id=workflow.id)
+
+        assert result['folder_name'] == 'Frontend_Development'
+
+    def test_generate_nonexistent_workflow_raises(self):
+        """ObjectDoesNotExist propagates for missing workflow."""
+        with pytest.raises(ObjectDoesNotExist):
+            WorkflowExportService.generate_workflow_files(workflow_id=99999)


### PR DESCRIPTION
## Summary
- Split `export_workflow_to_local` so the hosted API returns workflow/rule file **contents** as JSON instead of writing to the server filesystem
- HTTP MCP facade writes those files locally under `{target_directory}/{folder_name}/` and sibling `rules/`
- Added `WorkflowExportService.generate_workflow_files()`, unit/integration tests, and BDD scenario `FOB-WORKFLOWS-EXPORT_IMPORT-01c`

## Test plan
- [x] `pytest tests/unit/test_workflow_export_service.py` — 18 passed
- [x] `pytest tests/integration/test_workflow_export_import_mcp.py` — 12 passed
- [x] `pytest tests/integration/test_mcp_e2e_all_tools.py::TestMCPAllTools` — 85 passed, 1 skipped (pre-existing)
- [x] BDD scenarios `-01` and `-01c` marked complete in `workflows-export-import.feature`
- [x] Implementation plan `docs/plans/export_fix.md` todos marked completed

## Notes
- ORM-mode MCP (`mcp_integration/tools.py`) unchanged — still uses `export_workflow_to_markdown()` for local writes
- No UI changes; screen-flow diagram not updated
- Restart HTTP MCP facade after deploy to pick up `tools_http.py` changes