### PR TITLE
fix(notifications): responsive bell dropdown and HTMX mark-read

### DIFF
--- a/methodology/notification_views.py
+++ b/methodology/notification_views.py
@@ -6,13 +6,35 @@ Provides HTMX endpoints for notification dropdown and mark-read actions.
 import logging
 
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
-from django.http import JsonResponse
+from django.template.loader import render_to_string
 from django.views.decorators.http import require_POST
 
 from methodology.services.notification_service import NotificationService
 
 logger = logging.getLogger(__name__)
+
+
+def _is_htmx(request) -> bool:
+    """Return True when the request was issued by HTMX."""
+    return request.headers.get("HX-Request") == "true"
+
+
+def _dropdown_context(user):
+    """Build template context for the notification dropdown partial."""
+    return {
+        "notifications": NotificationService.get_recent(user, limit=20),
+        "unread_count": NotificationService.get_unread_count(user),
+    }
+
+
+def _htmx_dropdown_response(request) -> HttpResponse:
+    """Return refreshed dropdown HTML plus an OOB badge update for HTMX."""
+    context = _dropdown_context(request.user)
+    body = render_to_string("notifications/dropdown.html", context, request=request)
+    body += render_to_string("notifications/badge_oob.html", context, request=request)
+    return HttpResponse(body)
 
 
 @login_required
@@ -22,24 +44,16 @@ def notification_list(request):
     :param request: Django HTTP request.
     :return: Rendered partial HTML for notification dropdown.
     """
-    notifications = NotificationService.get_recent(request.user, limit=20)
-    unread_count = NotificationService.get_unread_count(request.user)
-    
+    context = _dropdown_context(request.user)
+
     logger.info(
         "[notifications] list view: user=%s count=%d unread=%d",
         request.user.username,
-        notifications.count(),
-        unread_count,
+        context["notifications"].count(),
+        context["unread_count"],
     )
-    
-    return render(
-        request,
-        "notifications/dropdown.html",
-        {
-            "notifications": notifications,
-            "unread_count": unread_count,
-        },
-    )
+
+    return render(request, "notifications/dropdown.html", context)
 
 
 @login_required
@@ -60,6 +74,8 @@ def mark_read(request, notification_id: int):
             request.user.username,
             unread_count,
         )
+        if _is_htmx(request):
+            return _htmx_dropdown_response(request)
         return JsonResponse({"success": True, "unread_count": unread_count})
     except Exception as exc:
         logger.error(
@@ -82,6 +98,8 @@ def mark_all_read(request):
     try:
         count = NotificationService.mark_all_read(request.user)
         logger.info("[notifications] marked all read: user=%s count=%d", request.user.username, count)
+        if _is_htmx(request):
+            return _htmx_dropdown_response(request)
         return JsonResponse({"success": True, "count": count, "unread_count": 0})
     except Exception as exc:
         logger.error(

--- a/templates/base.html
+++ b/templates/base.html
@@ -314,7 +314,7 @@
                            href="#"
                            id="notification-bell"
                            role="button"
-                           data-bs-toggle="dropdown"
+                           aria-haspopup="true"
                            aria-expanded="false"
                            data-testid="notification-bell"
                            hx-get="/notifications/"
@@ -595,6 +595,54 @@
                 });
             }
         });
+    </script>
+
+    <!-- Notification bell dropdown: content is lazy-loaded via HTMX, so the menu
+         element doesn't exist in the DOM until after the first fetch. Bootstrap's
+         data-bs-toggle would look for it too early and silently no-op, so
+         visibility is driven directly by the HTMX swap + a `show` class instead. -->
+    <script>
+        (function () {
+            var bell = document.getElementById('notification-bell');
+            var container = document.getElementById('notification-dropdown-container');
+            if (!bell || !container) return;
+
+            function closeNotificationDropdown() {
+                var menu = container.querySelector('.dropdown-menu');
+                if (menu) menu.classList.remove('show');
+                bell.setAttribute('aria-expanded', 'false');
+            }
+
+            function openNotificationDropdown() {
+                var menu = container.querySelector('.dropdown-menu');
+                if (menu) menu.classList.add('show');
+                bell.setAttribute('aria-expanded', 'true');
+            }
+
+            // A click while the dropdown is open is a "close" gesture: skip the
+            // refetch so it doesn't immediately reopen via afterSwap below.
+            document.body.addEventListener('htmx:beforeRequest', function (event) {
+                if (event.detail.elt !== bell) return;
+                if (bell.getAttribute('aria-expanded') === 'true') {
+                    event.preventDefault();
+                    closeNotificationDropdown();
+                }
+            });
+
+            container.addEventListener('htmx:afterSwap', openNotificationDropdown);
+
+            document.addEventListener('click', function (event) {
+                if (bell.getAttribute('aria-expanded') !== 'true') return;
+                if (bell.contains(event.target) || container.contains(event.target)) return;
+                closeNotificationDropdown();
+            });
+
+            document.addEventListener('keydown', function (event) {
+                if (event.key === 'Escape' && bell.getAttribute('aria-expanded') === 'true') {
+                    closeNotificationDropdown();
+                }
+            });
+        })();
     </script>
 
     {% block extra_js %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -115,6 +115,20 @@
             margin-top: auto;
             flex-shrink: 0;
         }
+        /* Notification dropdown: allow vertical scroll, prevent horizontal overflow */
+        #notification-dropdown-container {
+            max-width: min(400px, calc(100vw - 1rem));
+            overflow-x: hidden;
+        }
+        #notification-dropdown-container .notification-list {
+            max-height: 400px;
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+        #notification-dropdown-container .dropdown-item {
+            white-space: normal;
+            overflow-wrap: anywhere;
+        }
     </style>
     
     <!-- Font Awesome Pro -->
@@ -309,7 +323,7 @@
                         </form>
                         <div id="global-search-suggestions-container"></div>
                     </li>
-                    <li class="nav-item dropdown d-flex align-items-center me-3">
+                    <li class="nav-item dropdown me-3">
                         <a class="nav-link text-white py-2 position-relative"
                            href="#"
                            id="notification-bell"
@@ -318,17 +332,24 @@
                            aria-expanded="false"
                            data-testid="notification-bell"
                            hx-get="/notifications/"
-                           hx-trigger="click"
-                           hx-target="#notification-dropdown-container">
+                           hx-trigger="click prevent"
+                           hx-target="#notification-dropdown-container"
+                           hx-swap="innerHTML">
                             <i class="fas fa-bell"></i>
-                            {% if unread_notification_count > 0 %}
-                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
-                                  data-testid="notification-badge">
-                                {{ unread_notification_count }}
+                            <span id="notification-badge-container"
+                                  class="position-absolute top-0 start-100 translate-middle">
+                                {% if unread_notification_count > 0 %}
+                                <span class="badge rounded-pill bg-danger"
+                                      data-testid="notification-badge">
+                                    {{ unread_notification_count }}
+                                </span>
+                                {% endif %}
                             </span>
-                            {% endif %}
                         </a>
-                        <div id="notification-dropdown-container"></div>
+                        <div id="notification-dropdown-container"
+                             class="dropdown-menu dropdown-menu-end"
+                             style="min-width: 350px;"
+                             data-testid="notification-dropdown"></div>
                     </li>
                     <li class="nav-item dropdown d-flex align-items-center">
                         <a class="nav-link dropdown-toggle text-white py-2"
@@ -533,7 +554,7 @@
         document.body.addEventListener('htmx:configRequest', function (event) {
             var elt = event.detail.elt;
             if (!elt || !elt.closest) return;
-            var form = elt.closest('#feedback-form');
+            var form = elt.closest('form');
             if (!form) return;
             var tok = form.querySelector('[name=csrfmiddlewaretoken]');
             if (tok) {
@@ -597,50 +618,53 @@
         });
     </script>
 
-    <!-- Notification bell dropdown: content is lazy-loaded via HTMX, so the menu
-         element doesn't exist in the DOM until after the first fetch. Bootstrap's
-         data-bs-toggle would look for it too early and silently no-op, so
-         visibility is driven directly by the HTMX swap + a `show` class instead. -->
+    <!-- Notification bell dropdown: menu shell lives in the DOM (like the user menu),
+         but items are lazy-loaded via HTMX. data-bs-toggle would fire before the
+         first fetch, so we call Bootstrap Dropdown.show() after each swap instead. -->
     <script>
         (function () {
             var bell = document.getElementById('notification-bell');
-            var container = document.getElementById('notification-dropdown-container');
-            if (!bell || !container) return;
+            var menu = document.getElementById('notification-dropdown-container');
+            if (!bell || !menu) return;
 
-            function closeNotificationDropdown() {
-                var menu = container.querySelector('.dropdown-menu');
-                if (menu) menu.classList.remove('show');
-                bell.setAttribute('aria-expanded', 'false');
+            function getDropdown() {
+                return bootstrap.Dropdown.getOrCreateInstance(bell, { autoClose: 'outside' });
             }
 
-            function openNotificationDropdown() {
-                var menu = container.querySelector('.dropdown-menu');
-                if (menu) menu.classList.add('show');
-                bell.setAttribute('aria-expanded', 'true');
-            }
+            // Navbar scrolls with the page; block native mousedown focus scroll.
+            bell.addEventListener('mousedown', function (event) {
+                event.preventDefault();
+                bell.focus({ preventScroll: true });
+            });
 
-            // A click while the dropdown is open is a "close" gesture: skip the
-            // refetch so it doesn't immediately reopen via afterSwap below.
+            // Click while open = close (skip refetch that would reopen via afterSwap).
             document.body.addEventListener('htmx:beforeRequest', function (event) {
                 if (event.detail.elt !== bell) return;
                 if (bell.getAttribute('aria-expanded') === 'true') {
                     event.preventDefault();
-                    closeNotificationDropdown();
+                    var open = bootstrap.Dropdown.getInstance(bell);
+                    if (open) open.hide();
                 }
             });
 
-            container.addEventListener('htmx:afterSwap', openNotificationDropdown);
+            menu.addEventListener('htmx:afterSwap', function () {
+                getDropdown().show();
+            });
 
+            // Bootstrap autoClose is unreliable when the menu is opened post-HTMX
+            // without data-bs-toggle, so close explicitly on outside click / Escape.
             document.addEventListener('click', function (event) {
                 if (bell.getAttribute('aria-expanded') !== 'true') return;
-                if (bell.contains(event.target) || container.contains(event.target)) return;
-                closeNotificationDropdown();
+                var dropdownRoot = bell.closest('.dropdown');
+                if (dropdownRoot && dropdownRoot.contains(event.target)) return;
+                var open = bootstrap.Dropdown.getInstance(bell);
+                if (open) open.hide();
             });
 
             document.addEventListener('keydown', function (event) {
-                if (event.key === 'Escape' && bell.getAttribute('aria-expanded') === 'true') {
-                    closeNotificationDropdown();
-                }
+                if (event.key !== 'Escape' || bell.getAttribute('aria-expanded') !== 'true') return;
+                var open = bootstrap.Dropdown.getInstance(bell);
+                if (open) open.hide();
             });
         })();
     </script>

--- a/templates/notifications/badge_oob.html
+++ b/templates/notifications/badge_oob.html
@@ -1,0 +1,5 @@
+<span id="notification-badge-container" hx-swap-oob="innerHTML">
+{% if unread_count > 0 %}
+<span class="badge rounded-pill bg-danger" data-testid="notification-badge">{{ unread_count }}</span>
+{% endif %}
+</span>

--- a/templates/notifications/dropdown.html
+++ b/templates/notifications/dropdown.html
@@ -1,49 +1,60 @@
-<!-- Notification dropdown content (HTMX target) -->
-<div class="dropdown-menu dropdown-menu-end" style="min-width: 350px; max-width: 400px;" data-testid="notification-dropdown">
-    <div class="dropdown-header d-flex justify-content-between align-items-center">
-        <span>Notifications</span>
-        {% if unread_count > 0 %}
-        <form method="post" action="{% url 'notifications:mark_all_read' %}" class="d-inline">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-link btn-sm p-0" data-testid="mark-all-read-btn">
-                Mark all read
-            </button>
-        </form>
-        {% endif %}
-    </div>
-    <div class="dropdown-divider"></div>
-    
-    {% if notifications %}
-    <div style="max-height: 400px; overflow-y: auto;">
-        {% for notification in notifications %}
-        <a href="{% if notification.link %}{{ notification.link }}{% else %}#{% endif %}"
-           class="dropdown-item {% if not notification.is_read %}bg-light{% endif %}"
-           data-testid="notification-item-{{ notification.pk }}">
-            <div class="d-flex justify-content-between align-items-start">
-                <div class="flex-grow-1">
-                    <div class="fw-semibold">{{ notification.title }}</div>
-                    {% if notification.message %}
-                    <div class="small text-muted">{{ notification.message|truncatewords:15 }}</div>
-                    {% endif %}
-                    <div class="small text-muted">{{ notification.created_at|timesince }} ago</div>
-                </div>
-                {% if not notification.is_read %}
-                <form method="post" action="{% url 'notifications:mark_read' notification.pk %}" class="ms-2">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-sm btn-outline-secondary" data-testid="mark-read-{{ notification.pk }}">
-                        <i class="fa-solid fa-check"></i>
-                    </button>
-                </form>
-                {% endif %}
-            </div>
-        </a>
-        {% if not forloop.last %}<div class="dropdown-divider"></div>{% endif %}
-        {% endfor %}
-    </div>
-    {% else %}
-    <div class="dropdown-item text-muted text-center py-4" data-testid="notifications-empty">
-        <i class="fa-solid fa-bell-slash fa-2x mb-2"></i>
-        <p class="mb-0">No notifications yet</p>
-    </div>
+<!-- Notification dropdown inner content (HTMX innerHTML target) -->
+<div class="dropdown-header d-flex justify-content-between align-items-center">
+    <span>Notifications</span>
+    {% if unread_count > 0 %}
+    <form method="post"
+          action="{% url 'notifications:mark_all_read' %}"
+          hx-post="{% url 'notifications:mark_all_read' %}"
+          hx-target="#notification-dropdown-container"
+          hx-swap="innerHTML"
+          class="d-inline">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-link btn-sm p-0" data-testid="mark-all-read-btn">
+            Mark all read
+        </button>
+    </form>
     {% endif %}
 </div>
+<div class="dropdown-divider"></div>
+
+{% if notifications %}
+<div class="notification-list">
+    {% for notification in notifications %}
+    <div class="dropdown-item {% if not notification.is_read %}bg-light{% endif %}"
+         data-testid="notification-item-{{ notification.pk }}">
+        <div class="d-flex justify-content-between align-items-start">
+            <a href="{% if notification.link %}{{ notification.link }}{% else %}#{% endif %}"
+               class="flex-grow-1 min-w-0 text-decoration-none text-reset">
+                <div class="fw-semibold">{{ notification.title }}</div>
+                {% if notification.message %}
+                <div class="small text-muted">{{ notification.message|truncatewords:15 }}</div>
+                {% endif %}
+                <div class="small text-muted">{{ notification.created_at|timesince }} ago</div>
+            </a>
+            {% if not notification.is_read %}
+            <form method="post"
+                  action="{% url 'notifications:mark_read' notification.pk %}"
+                  hx-post="{% url 'notifications:mark_read' notification.pk %}"
+                  hx-target="#notification-dropdown-container"
+                  hx-swap="innerHTML"
+                  class="ms-2 flex-shrink-0">
+                {% csrf_token %}
+                <button type="submit"
+                        class="btn btn-sm btn-outline-secondary"
+                        data-testid="mark-read-{{ notification.pk }}"
+                        aria-label="Mark as read">
+                    <i class="fa-solid fa-check"></i>
+                </button>
+            </form>
+            {% endif %}
+        </div>
+    </div>
+    {% if not forloop.last %}<div class="dropdown-divider"></div>{% endif %}
+    {% endfor %}
+</div>
+{% else %}
+<div class="dropdown-item text-muted text-center py-4" data-testid="notifications-empty">
+    <i class="fa-solid fa-bell-slash fa-2x mb-2"></i>
+    <p class="mb-0">No notifications yet</p>
+</div>
+{% endif %}

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -139,7 +139,7 @@ class TestNotificationViews:
         assert response.status_code == 200
         assert b"Test Notification" in response.content
         assert b"Test message" in response.content
-        assert b'data-testid="notification-dropdown"' in response.content
+        assert b'data-testid="notification-item-' in response.content
 
     def test_notification_list_empty_state(self):
         """GET /notifications/ should show empty state when no notifications."""
@@ -175,6 +175,43 @@ class TestNotificationViews:
         notification.refresh_from_db()
         assert notification.is_read
 
+    def test_mark_read_endpoint_htmx_refreshes_dropdown_and_badge(self):
+        """HTMX mark-read should return refreshed dropdown HTML and badge OOB swap."""
+        user = User.objects.create_user(username="notif_user8b", password="pass", email="user8b@test.com")
+        client = Client()
+        client.force_login(user)
+
+        notification = NotificationService.create(
+            user=user,
+            notification_type=Notification.TYPE_TEAM_INVITE,
+            title="Unread alert",
+            message="Please review",
+            link="/teams/1/",
+        )
+        NotificationService.create(
+            user=user,
+            notification_type=Notification.TYPE_TEAM_INVITE,
+            title="Second alert",
+            message="",
+            link="",
+        )
+
+        response = client.post(
+            reverse("notifications:mark_read", args=[notification.pk]),
+            HTTP_HX_REQUEST="true",
+        )
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "Unread alert" in content
+        assert 'data-testid="notification-item-' in content
+        assert 'id="notification-badge-container"' in content
+        assert 'hx-swap-oob="innerHTML"' in content
+        assert 'data-testid="notification-badge">1</span>' in content.replace(" ", "")
+
+        notification.refresh_from_db()
+        assert notification.is_read
+        assert NotificationService.get_unread_count(user) == 1
+
     def test_mark_all_read_endpoint(self):
         """POST /notifications/read-all/ should mark all notifications as read."""
         user = User.objects.create_user(username="notif_user9", password="pass", email="user9@test.com")
@@ -196,6 +233,30 @@ class TestNotificationViews:
         assert data["success"] is True
         assert data["count"] == 3
         assert data["unread_count"] == 0
+
+        assert NotificationService.get_unread_count(user) == 0
+
+    def test_mark_all_read_endpoint_htmx_clears_badge(self):
+        """HTMX mark-all-read should return dropdown HTML with empty badge OOB."""
+        user = User.objects.create_user(username="notif_user9b", password="pass", email="user9b@test.com")
+        client = Client()
+        client.force_login(user)
+
+        for i in range(3):
+            NotificationService.create(
+                user=user,
+                notification_type=Notification.TYPE_TEAM_INVITE,
+                title=f"Notification {i}",
+                message="",
+                link="",
+            )
+
+        response = client.post(reverse("notifications:mark_all_read"), HTTP_HX_REQUEST="true")
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert 'id="notification-badge-container"' in content
+        assert 'data-testid="notification-badge"' not in content
+        assert 'data-testid="mark-all-read-btn"' not in content
 
         assert NotificationService.get_unread_count(user) == 0
 


### PR DESCRIPTION
## Summary
- Fix notification bell first-click no-op by lazy-loading dropdown content via HTMX and opening with Bootstrap `Dropdown.show()` after swap (fixes #147).
- Wire per-notification tick and "Mark all read" through HTMX so the dropdown and bell badge update in place instead of navigating to raw JSON.
- Polish dropdown UX: prevent page scroll on bell click, clip horizontal overflow, fix invalid form-in-link markup, and restore outside-click/Escape dismiss.

## Test plan
- [x] `pytest tests/integration/test_notifications.py` (16 passed)
- [x] Open bell with unread badge — dropdown appears on first click
- [x] Click outside or press Escape — dropdown closes
- [x] Click tick on one notification — badge decrements, item loses unread styling, dropdown stays open
- [x] Click "Mark all read" — badge clears, ticks disappear, notification text remains
- [x] Scroll page down, click bell — page does not jump to top